### PR TITLE
Added set frame data methods to Pixel and exported Pixel from library

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,33 @@
 import log from 'loglevel';
 
+// Namespace constants
+
+declare namespace PhotometricInterpretation {
+  const Monochrome1: string;
+  const Monochrome2: string;
+  const PaletteColor: string;
+  const Rgb: string;
+  const YbrFull: string;
+  const YbrFull422: string;
+  const YbrPartial422: string;
+  const YbrPartial420: string;
+  const YbrIct: string;
+  const YbrRct: string;
+  const Cmyk: string;
+  const Argb: string;
+  const Hsv: string;
+}
+
+declare namespace PixelRepresentation {
+  const Unsigned: number;
+  const Signed: number;
+}
+
+declare namespace PlanarConfiguration {
+  const Interleaved: number;
+  const Planar: number;
+}
+
 declare namespace StandardColorPalette {
   const Grayscale: number;
   const HotIron: number;
@@ -27,6 +55,7 @@ declare namespace TransferSyntax {
   const HtJpeg2000Lossy: string;
 }
 
+// Utility classes
 declare class Histogram {
   /**
    * Creates an instance of Histogram.
@@ -116,26 +145,7 @@ declare class WindowLevel {
   toString(): string;
 }
 
-declare class NativePixelDecoder {
-  /**
-   * Initializes native pixel decoder.
-   */
-  static initializeAsync(opts?: {
-    webAssemblyModulePathOrUrl?: string;
-    logNativeDecodersMessages?: boolean;
-  }): Promise<void>;
-
-  /**
-   * Checks if native pixel decoder module is initialized.
-   */
-  static isInitialized(): boolean;
-
-  /**
-   * Releases native pixel decoder module.
-   */
-  static release(): void;
-}
-
+// Core classes
 declare class DicomImage {
   /**
    * Creates an instance of DicomImage.
@@ -235,14 +245,337 @@ declare class DicomImage {
   toString(): string;
 }
 
+declare class Pixel {
+  /**
+   * Creates an instance of Pixel.
+   */
+  constructor(elements: Record<string, unknown>, transferSyntaxUid: string);
+
+  /**
+   * Gets the transfer syntax UID.
+   */
+  getTransferSyntaxUid(): string;
+
+  /**
+   * Gets the number of frames.
+   */
+  getNumberOfFrames(): number;
+
+  /**
+   * Gets the image width.
+   */
+  getWidth(): number;
+
+  /**
+   * Gets the image height.
+   */
+  getHeight(): number;
+
+  /**
+   * Gets bits stored.
+   */
+  getBitsStored(): number;
+
+  /**
+   * Gets bits allocated.
+   */
+  getBitsAllocated(): number;
+
+  /**
+   * Gets bytes allocated.
+   */
+  getBytesAllocated(): number;
+
+  /**
+   * Gets high bit.
+   */
+  getHighBit(): number;
+
+  /**
+   * Gets samples per pixel.
+   */
+  getSamplesPerPixel(): number;
+
+  /**
+   * Gets pixel representation.
+   */
+  getPixelRepresentation(): number;
+
+  /**
+   * Checks if pixel data is signed.
+   */
+  isSigned(): boolean;
+
+  /**
+   * Gets minimum pixel value.
+   */
+  getMinimumPixelValue(): number;
+
+  /**
+   * Gets maximum pixel value.
+   */
+  getMaximumPixelValue(): number;
+
+  /**
+   * Gets planar configuration.
+   */
+  getPlanarConfiguration(): number;
+
+  /**
+   * Checks if pixel data is planar.
+   */
+  isPlanar(): boolean;
+
+  /**
+   * Gets photometric interpretation.
+   */
+  getPhotometricInterpretation(): string;
+
+  /**
+   * Gets uncompressed frame size.
+   */
+  getUncompressedFrameSize(): number;
+
+  /**
+   * Gets rescale slope.
+   */
+  getRescaleSlope(): number;
+
+  /**
+   * Gets rescale intercept.
+   */
+  getRescaleIntercept(): number;
+
+  /**
+   * Gets VOI LUT function.
+   */
+  getVoiLutFunction(): string;
+
+  /**
+   * Gets smallest image pixel value.
+   */
+  getSmallestImagePixelValue(): number | undefined;
+
+  /**
+   * Gets largest image pixel value.
+   */
+  getLargestImagePixelValue(): number | undefined;
+
+  /**
+   * Gets pixel padding value.
+   */
+  getPixelPaddingValue(): number | undefined;
+
+  /**
+   * Gets red palette color lookup table descriptor.
+   */
+  getRedPaletteColorLookupTableDescriptor(): unknown;
+
+  /**
+   * Gets red palette color lookup table data.
+   */
+  getRedPaletteColorLookupTableData(): unknown;
+
+  /**
+   * Gets green palette color lookup table data.
+   */
+  getGreenPaletteColorLookupTableData(): unknown;
+
+  /**
+   * Gets blue palette color lookup table data.
+   */
+  getBluePaletteColorLookupTableData(): unknown;
+
+  /**
+   * Gets pixel data.
+   */
+  getPixelData(): ArrayBuffer | undefined;
+
+  /**
+   * Checks if pixel data is float.
+   */
+  hasFloatPixelData(): boolean;
+
+  /**
+   * Gets frame data as Uint8Array.
+   */
+  getFrameDataU8(frame: number): Uint8Array;
+
+  /**
+   * Sets frame data from Uint8Array.
+   */
+  setFrameDataU8(frame: number, data: Uint8Array): void;
+
+  /**
+   * Gets frame data as Uint16Array.
+   */
+  getFrameDataU16(frame: number): Uint16Array;
+
+  /**
+   * Sets frame data from Uint16Array.
+   */
+  setFrameDataU16(frame: number, data: Uint16Array): void;
+
+  /**
+   * Gets frame data as Int16Array.
+   */
+  getFrameDataS16(frame: number): Int16Array;
+
+  /**
+   * Sets frame data from Int16Array.
+   */
+  setFrameDataS16(frame: number, data: Int16Array): void;
+
+  /**
+   * Gets frame data as Uint32Array.
+   */
+  getFrameDataU32(frame: number): Uint32Array;
+
+  /**
+   * Sets frame data from Uint32Array.
+   */
+  setFrameDataU32(frame: number, data: Uint32Array): void;
+
+  /**
+   * Gets frame data as Int32Array.
+   */
+  getFrameDataS32(frame: number): Int32Array;
+
+  /**
+   * Sets frame data from Int32Array.
+   */
+  setFrameDataS32(frame: number, data: Int32Array): void;
+
+  /**
+   * Gets frame data as Float32Array.
+   */
+  getFrameDataF32(frame: number): Float32Array;
+
+  /**
+   * Sets frame data from Float32Array.
+   */
+  setFrameDataF32(frame: number, data: Float32Array): void;
+
+  /**
+   * Gets frame data in appropriate typed array format.
+   */
+  getFrameData(
+    frame: number
+  ): Uint8Array | Uint16Array | Int16Array | Uint32Array | Int32Array | Float32Array;
+
+  /**
+   * Sets frame data from appropriate typed array format.
+   */
+  setFrameData(
+    frame: number,
+    data: Uint8Array | Uint16Array | Int16Array | Uint32Array | Int32Array | Float32Array
+  ): void;
+
+  /**
+   * Gets the pixel description.
+   */
+  toString(): string;
+}
+
+declare class NativePixelDecoder {
+  /**
+   * Initializes native pixel decoder.
+   */
+  static initializeAsync(opts?: {
+    webAssemblyModulePathOrUrl?: string;
+    logNativeDecodersMessages?: boolean;
+  }): Promise<void>;
+
+  /**
+   * Checks if native pixel decoder module is initialized.
+   */
+  static isInitialized(): boolean;
+
+  /**
+   * Releases native pixel decoder module.
+   */
+  static release(): void;
+}
+
+declare class NativePixelEncoder {
+  /**
+   * Initializes native pixel encoder.
+   */
+  static initializeAsync(opts?: {
+    webAssemblyModulePathOrUrl?: string;
+    logNativeEncodersMessages?: boolean;
+  }): Promise<void>;
+
+  /**
+   * Checks if native pixel encoder module is initialized.
+   */
+  static isInitialized(): boolean;
+
+  /**
+   * Releases native pixel encoder module.
+   */
+  static release(): void;
+
+  /**
+   * Encodes pixel data using RLE compression.
+   */
+  static encodeRle(
+    pixel: Pixel,
+    data: ArrayBuffer,
+    parameters?: Record<string, unknown>
+  ): ArrayBuffer;
+
+  /**
+   * Encodes pixel data using JPEG compression.
+   */
+  static encodeJpeg(
+    pixel: Pixel,
+    data: ArrayBuffer,
+    parameters?: Record<string, unknown>
+  ): ArrayBuffer;
+
+  /**
+   * Encodes pixel data using JPEG-LS compression.
+   */
+  static encodeJpegLs(
+    pixel: Pixel,
+    data: ArrayBuffer,
+    parameters?: Record<string, unknown>
+  ): ArrayBuffer;
+
+  /**
+   * Encodes pixel data using JPEG 2000 compression.
+   */
+  static encodeJpeg2000(
+    pixel: Pixel,
+    data: ArrayBuffer,
+    parameters?: Record<string, unknown>
+  ): ArrayBuffer;
+}
+
+// Constants
 /**
  * Version.
  */
 declare const version: string;
 
+// Exports
+
 export namespace constants {
+  export { PhotometricInterpretation };
+  export { PixelRepresentation };
+  export { PlanarConfiguration };
   export { StandardColorPalette };
   export { TransferSyntax };
 }
 
-export { DicomImage, NativePixelDecoder, WindowLevel, Histogram, log, version };
+export {
+  DicomImage,
+  NativePixelDecoder,
+  NativePixelEncoder,
+  WindowLevel,
+  Histogram,
+  Pixel,
+  log,
+  version,
+};

--- a/src/NativePixelDecoder.js
+++ b/src/NativePixelDecoder.js
@@ -15,14 +15,16 @@ class NativePixelDecoder {
    * to log native pixel decoder informational messages.
    */
   static async initializeAsync(opts) {
-    opts = opts || {};
-    this.logNativeDecodersMessages = opts.logNativeDecodersMessages || false;
-    this.webAssemblyModulePathOrUrl = opts.webAssemblyModulePathOrUrl;
+    if (NativeCodecs.isInitialized()) {
+      return; // Already initialized
+    }
 
+    opts = opts || {};
+    // Map old parameter name to new one for backward compatibility
     await NativeCodecs.initializeAsync({
-      webAssemblyModulePathOrUrl: this.webAssemblyModulePathOrUrl,
-      logCodecsInfo: this.logNativeDecodersMessages,
-      logCodecsTrace: this.logNativeDecodersMessages,
+      webAssemblyModulePathOrUrl: opts.webAssemblyModulePathOrUrl,
+      logCodecsInfo: opts.logNativeEncodersMessages || false,
+      logCodecsTrace: opts.logNativeEncodersMessages || false,
     });
   }
 

--- a/src/NativePixelEncoder.js
+++ b/src/NativePixelEncoder.js
@@ -1,0 +1,154 @@
+const { Context, NativeCodecs } = require('dcmjs-codecs');
+const { PixelRepresentation, PlanarConfiguration } = require('./Constants');
+
+//#region NativePixelEncoder
+class NativePixelEncoder {
+  /**
+   * Initializes native pixel encoder.
+   * @method
+   * @static
+   * @async
+   * @param {Object} [opts] - Native pixel encoder options.
+   * @param {string} [opts.webAssemblyModulePathOrUrl] - Custom WebAssembly module path or URL.
+   * If not provided, the module is trying to be resolved within the same directory.
+   * @param {boolean} [opts.logNativeEncodersMessages] - Flag to indicate whether
+   * to log native pixel encoder informational messages.
+   */
+  static async initializeAsync(opts) {
+    if (NativeCodecs.isInitialized()) {
+      return; // Already initialized
+    }
+
+    opts = opts || {};
+    // Map old parameter name to new one for backward compatibility
+    await NativeCodecs.initializeAsync({
+      webAssemblyModulePathOrUrl: opts.webAssemblyModulePathOrUrl,
+      logCodecsInfo: opts.logNativeEncodersMessages || false,
+      logCodecsTrace: opts.logNativeEncodersMessages || false,
+    });
+  }
+
+  /**
+   * Checks if native codecs module is initialized.
+   * @method
+   * @static
+   * @returns {boolean} A flag indicating whether native codecs module is initialized.
+   */
+  static isInitialized() {
+    return NativeCodecs.isInitialized();
+  }
+
+  /**
+   * Releases native codecs.
+   * @method
+   * @static
+   */
+  static release() {
+    return NativeCodecs.release();
+  }
+
+  /**
+   * Encodes frame using RLE compression.
+   * @method
+   * @static
+   * @param {Pixel} pixel - Pixel object.
+   * @param {Uint8Array} data - Uncompressed pixels data.
+   * @param {Object} [parameters] - Encoder parameters.
+   * @returns {Uint8Array} Encoded pixels data.
+   * @throws Error if NativePixelEncoder module is not initialized.
+   */
+  static encodeRle(pixel, data, parameters) {
+    const context = this._createEncodingContext(pixel, data);
+    const encodedContext = NativeCodecs.encodeRle(context, parameters);
+
+    return encodedContext.getEncodedBuffer();
+  }
+
+  /**
+   * Encodes frame using JPEG compression (lossless or lossy).
+   * @method
+   * @static
+   * @param {Pixel} pixel - Pixel object.
+   * @param {Uint8Array} data - Uncompressed pixels data.
+   * @param {Object} [parameters] - Encoder parameters.
+   * @param {number} [parameters.quality] - JPEG quality factor (1-100).
+   * @param {boolean} [parameters.lossless] - Use lossless JPEG encoding.
+   * @returns {Uint8Array} Encoded pixels data.
+   * @throws Error if NativePixelEncoder module is not initialized.
+   */
+  static encodeJpeg(pixel, data, parameters) {
+    const context = this._createEncodingContext(pixel, data);
+    const encodedContext = NativeCodecs.encodeJpeg(context, parameters);
+
+    return encodedContext.getEncodedBuffer();
+  }
+
+  /**
+   * Encodes frame using JPEG-LS compression.
+   * @method
+   * @static
+   * @param {Pixel} pixel - Pixel object.
+   * @param {Uint8Array} data - Uncompressed pixels data.
+   * @param {Object} [parameters] - Encoder parameters.
+   * @param {number} [parameters.nearLossless] - Near-lossless compression parameter (0 for lossless).
+   * @returns {Uint8Array} Encoded pixels data.
+   * @throws Error if NativePixelEncoder module is not initialized.
+   */
+  static encodeJpegLs(pixel, data, parameters) {
+    const context = this._createEncodingContext(pixel, data);
+    const encodedContext = NativeCodecs.encodeJpegLs(context, parameters);
+
+    return encodedContext.getEncodedBuffer();
+  }
+
+  /**
+   * Encodes frame using JPEG2000 compression.
+   * @method
+   * @static
+   * @param {Pixel} pixel - Pixel object.
+   * @param {Uint8Array} data - Uncompressed pixels data.
+   * @param {Object} [parameters] - Encoder parameters.
+   * @param {number} [parameters.compressionRatio] - Compression ratio for lossy encoding.
+   * @param {boolean} [parameters.lossless] - Use lossless JPEG2000 encoding.
+   * @returns {Uint8Array} Encoded pixels data.
+   * @throws Error if NativePixelEncoder module is not initialized.
+   */
+  static encodeJpeg2000(pixel, data, parameters) {
+    const context = this._createEncodingContext(pixel, data);
+    const encodedContext = NativeCodecs.encodeJpeg2000(context, parameters);
+
+    return encodedContext.getEncodedBuffer();
+  }
+
+  /**
+   * Creates an encoding context.
+   * @method
+   * @static
+   * @private
+   * @param {Pixel} pixel - Pixel object.
+   * @param {Uint8Array} data - Uncompressed pixels data.
+   * @returns {Context} Encoding context.
+   */
+  static _createEncodingContext(pixel, data) {
+    return new Context({
+      width: pixel.getWidth(),
+      height: pixel.getHeight(),
+      bitsAllocated: pixel.getBitsAllocated(),
+      bitsStored: pixel.getBitsStored(),
+      samplesPerPixel: pixel.getSamplesPerPixel(),
+      pixelRepresentation: pixel.getPixelRepresentation()
+        ? PixelRepresentation.Signed
+        : PixelRepresentation.Unsigned,
+      planarConfiguration: pixel.getPlanarConfiguration()
+        ? PlanarConfiguration.Interleaved
+        : PlanarConfiguration.Planar,
+      photometricInterpretation: pixel.getPhotometricInterpretation(),
+      decodedBuffer: data, // For encoding, we provide the uncompressed data as decodedBuffer
+    });
+  }
+}
+//#endregion
+
+//#region Exports
+module.exports = NativePixelEncoder;
+//#endregion

--- a/src/Pixel.js
+++ b/src/Pixel.js
@@ -593,11 +593,10 @@ class Pixel {
       photometricInterpretation === PhotometricInterpretation.PaletteColor
     ) {
       if (this.getBitsStored() === 1) {
-        this.setFrameDataU8(frame, SingleBitPixelPipeline._shrinkBytes(
-          this.getWidth(),
-          this.getHeight(),
-          data
-        ));
+        this.setFrameDataU8(
+          frame,
+          SingleBitPixelPipeline._shrinkBytes(this.getWidth(), this.getHeight(), data)
+        );
       } else if (
         this.getBitsAllocated() === 8 &&
         this.getHighBit() === 7 &&
@@ -626,11 +625,9 @@ class Pixel {
     ) {
       if (this.getPlanarConfiguration() === PlanarConfiguration.Planar) {
         this.setFrameDataU8(frame, PixelConverter.interleaved24ToPlanar(data));
-      }
-      else {
+      } else {
         this.setFrameDataU8(frame, data);
       }
-      
     } else {
       throw new Error(
         `Unsupported pixel data photometric interpretation: ${photometricInterpretation}`

--- a/src/Pixel.js
+++ b/src/Pixel.js
@@ -359,6 +359,16 @@ class Pixel {
   }
 
   /**
+   * Sets the pixel data from an array of unsigned byte values.
+   * @method
+   * @param {number} frame - Frame index.
+   * @param {Uint8Array} data - Pixel data as an array of unsigned byte values.
+   */
+  setFrameDataU8(frame, data) {
+    this._setFrameBuffer(frame, data);
+  }
+
+  /**
    * Gets the pixel data as an array of unsigned short values.
    * @method
    * @param {number} frame - Frame index.
@@ -372,6 +382,17 @@ class Pixel {
       frameBuffer.byteOffset,
       frameBuffer.byteLength / Uint16Array.BYTES_PER_ELEMENT
     );
+  }
+
+  /**
+   * Sets the pixel data from an array of unsigned short values.
+   * @method
+   * @param {number} frame - Frame index.
+   * @param {Uint16Array} data - Pixel data as an array of unsigned short values.
+   */
+  setFrameDataU16(frame, data) {
+    const frameBuffer = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    this._setFrameBuffer(frame, frameBuffer);
   }
 
   /**
@@ -397,6 +418,28 @@ class Pixel {
   }
 
   /**
+   * Sets the pixel data from an array of signed short values.
+   * @method
+   * @param {number} frame - Frame index.
+   * @param {Int16Array} data - Pixel data as an array of signed short values.
+   */
+  setFrameDataS16(frame, data) {
+    const s16 = new Int16Array(data);
+
+    if (this.getBitsStored() !== 16) {
+      const shiftLeft = this.getBitsAllocated() - this.getBitsStored();
+      const shiftRight = this.getBitsAllocated() - this.getHighBit() - 1;
+      for (let i = 0; i < s16.length; i++) {
+        s16[i] <<= shiftLeft;
+        s16[i] >>= shiftRight;
+      }
+    }
+
+    const u16 = new Uint16Array(s16.buffer, s16.byteOffset, s16.length);
+    this.setFrameDataU16(frame, u16);
+  }
+
+  /**
    * Gets the pixel data as an array of unsigned integer values.
    * @method
    * @param {number} frame - Frame index.
@@ -413,6 +456,17 @@ class Pixel {
   }
 
   /**
+   * Sets the pixel data from an array of unsigned integer values.
+   * @method
+   * @param {number} frame - Frame index.
+   * @param {Uint32Array} data - Pixel data as an array of unsigned integer values.
+   */
+  setFrameDataU32(frame, data) {
+    const frameBuffer = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    this._setFrameBuffer(frame, frameBuffer);
+  }
+
+  /**
    * Gets the pixel data as an array of signed integer values.
    * @method
    * @param {number} frame - Frame index.
@@ -423,6 +477,17 @@ class Pixel {
     const s32 = new Int32Array(u32);
 
     return s32;
+  }
+
+  /**
+   * Sets the pixel data from an array of signed integer values.
+   * @method
+   * @param {number} frame - Frame index.
+   * @param {Int32Array} data - Pixel data as an array of signed integer values.
+   */
+  setFrameDataS32(frame, data) {
+    const u32 = new Uint32Array(data.buffer, data.byteOffset, data.length);
+    this.setFrameDataU32(frame, u32);
   }
 
   /**
@@ -439,6 +504,17 @@ class Pixel {
       frameBuffer.byteOffset,
       frameBuffer.byteLength / Float32Array.BYTES_PER_ELEMENT
     );
+  }
+
+  /**
+   * Sets the pixel data from an array of float values.
+   * @method
+   * @param {number} frame - Frame index.
+   * @param {Float32Array} data - Pixel data as an array of float values.
+   */
+  setFrameDataF32(frame, data) {
+    const frameBuffer = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    this._setFrameBuffer(frame, frameBuffer);
   }
 
   /**

--- a/src/Pixel.js
+++ b/src/Pixel.js
@@ -756,7 +756,9 @@ class Pixel {
 
       if (Array.isArray(pixelBuffers)) {
         // Find the appropriate buffer and update it
-        const targetBuffer = pixelBuffers.find((buffer) => buffer && buffer.byteLength > frameOffset);
+        const targetBuffer = pixelBuffers.find(
+          (buffer) => buffer && buffer.byteLength > frameOffset
+        );
         if (targetBuffer) {
           const pixelBuffer = new Uint8Array(targetBuffer);
           pixelBuffer.set(processedFrameData, frameOffset);
@@ -1376,6 +1378,38 @@ class SingleBitPixelPipeline extends GrayscalePixelPipeline {
       }
       const bitValue = (byteValue >>> bitIndex) & 0x01;
       output[i] = bitValue ? 1 : 0;
+    }
+
+    return output;
+  }
+
+  /**
+   * Shrinks bytes to image bits.
+   * @method
+   * @static
+   * @private
+   * @param {number} width - Image width.
+   * @param {number} height - Image height.
+   * @param {Uint8Array} data - Pixel data (bytes containing 0 or 1).
+   * @returns {Uint8Array} Packed bits.
+   * @throws {Error} If an array item is not 0 or 1.
+   */
+  static _shrinkBytes(width, height, data) {
+    const totalPixels = width * height;
+    const outputSize = Math.ceil(totalPixels / 8);
+    const output = new Uint8Array(outputSize);
+
+    for (let i = 0; i < totalPixels; i++) {
+      const pixelValue = data[i];
+      if (pixelValue !== 0 && pixelValue !== 1) {
+        throw new Error('Array item must be 0 or 1');
+      }
+
+      if (pixelValue === 1) {
+        const byteIndex = Math.floor(i / 8);
+        const bitIndex = i - 8 * byteIndex;
+        output[byteIndex] |= 1 << bitIndex;
+      }
     }
 
     return output;

--- a/src/Pixel.js
+++ b/src/Pixel.js
@@ -584,7 +584,6 @@ class Pixel {
       );
     }
 
-    const pixelBuffers = this.getPixelData();
     if (
       this.getTransferSyntaxUid() === TransferSyntax.ImplicitVRLittleEndian ||
       this.getTransferSyntaxUid() === TransferSyntax.ExplicitVRLittleEndian ||
@@ -596,7 +595,7 @@ class Pixel {
 
       // Take the first buffer from pixel buffers and extract the current frame data
       let pixelBuffer = new Uint8Array(
-        Array.isArray(pixelBuffers) ? pixelBuffers.find((o) => o) : pixelBuffers
+        Array.isArray(pixelData) ? pixelData.find((o) => o) : pixelData
       );
       const framePixelBuffer = pixelBuffer.slice(frameOffset, frameOffset + frameSize);
 
@@ -633,7 +632,7 @@ class Pixel {
 
       return framePixelBuffer;
     } else {
-      const frameFragmentsData = this._getFrameFragments(pixelBuffers, frame);
+      const frameFragmentsData = this._getFrameFragments(pixelData, frame);
       if (this.getTransferSyntaxUid() === TransferSyntax.RleLossless) {
         return NativePixelDecoder.decodeRle(this, frameFragmentsData);
       } else if (

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const {
   TransferSyntax,
 } = require('./Constants');
 const DicomImage = require('./DicomImage');
+const { Pixel } = require('./Pixel');
 const NativePixelDecoder = require('./NativePixelDecoder');
 const NativePixelEncoder = require('./NativePixelEncoder');
 const WindowLevel = require('./WindowLevel');
@@ -28,6 +29,7 @@ const DcmjsImaging = {
   DicomImage,
   Histogram,
   log,
+  Pixel,
   NativePixelDecoder,
   NativePixelEncoder,
   version,

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const {
 } = require('./Constants');
 const DicomImage = require('./DicomImage');
 const NativePixelDecoder = require('./NativePixelDecoder');
+const NativePixelEncoder = require('./NativePixelEncoder');
 const WindowLevel = require('./WindowLevel');
 const Histogram = require('./Histogram');
 const log = require('./log');
@@ -28,6 +29,7 @@ const DcmjsImaging = {
   Histogram,
   log,
   NativePixelDecoder,
+  NativePixelEncoder,
   version,
   WindowLevel,
 };

--- a/test/NativePixelEncoder.test.js
+++ b/test/NativePixelEncoder.test.js
@@ -1,0 +1,563 @@
+const { Pixel } = require('./../src/Pixel');
+const {
+  PhotometricInterpretation,
+  PixelRepresentation,
+  TransferSyntax,
+} = require('./../src/Constants');
+const NativePixelEncoder = require('./../src/NativePixelEncoder');
+const NativePixelDecoder = require('./../src/NativePixelDecoder');
+
+const { createImageFromPixelData } = require('./utils');
+
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Uninitialized NativePixelEncoder', () => {
+  it('should throw for uninitialized NativePixelEncoder', () => {
+    const width = 3;
+    const height = 3;
+    const testData = Uint8Array.from([0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00]);
+
+    const monoImage = createImageFromPixelData(
+      width,
+      height,
+      8,
+      8,
+      1,
+      PixelRepresentation.Unsigned,
+      PhotometricInterpretation.Monochrome2,
+      testData.buffer,
+      TransferSyntax.ExplicitVRLittleEndian
+    );
+    const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+    expect(() => {
+      NativePixelEncoder.encodeRle(pixel, testData);
+    }).to.throw();
+    expect(() => {
+      NativePixelEncoder.encodeJpeg(pixel, testData);
+    }).to.throw();
+    expect(() => {
+      NativePixelEncoder.encodeJpegLs(pixel, testData);
+    }).to.throw();
+    expect(() => {
+      NativePixelEncoder.encodeJpeg2000(pixel, testData);
+    }).to.throw();
+    expect(() => {
+      NativePixelEncoder.encodeJpegXl(pixel, testData);
+    }).to.throw();
+    expect(() => {
+      NativePixelEncoder.encodeHtJpeg2000(pixel, testData);
+    }).to.throw();
+  });
+});
+
+describe('NativePixelEncoder', () => {
+  before(async () => {
+    const isNodeJs = !!(
+      typeof process !== 'undefined' &&
+      process.versions &&
+      process.versions.node
+    );
+    const webAssemblyModulePathOrUrl = !isNodeJs
+      ? 'base/node_modules/dcmjs-codecs/build/dcmjs-native-codecs.wasm'
+      : undefined;
+
+    // Initialize both encoder and decoder for round-trip testing
+    await NativePixelEncoder.initializeAsync({
+      webAssemblyModulePathOrUrl,
+      logNativeEncodersMessages: true,
+    });
+    await NativePixelDecoder.initializeAsync({
+      webAssemblyModulePathOrUrl,
+      logNativeDecodersMessages: true,
+    });
+  });
+
+  after(() => {
+    NativePixelEncoder.release();
+    NativePixelDecoder.release();
+  });
+
+  it('should correctly return initialization status', () => {
+    expect(NativePixelEncoder.isInitialized()).to.be.eq(true);
+  });
+
+  it('should handle multiple initialization calls gracefully', async () => {
+    // Since it's already initialized, this should return early without error
+    expect(NativePixelEncoder.isInitialized()).to.be.eq(true);
+
+    // Call initializeAsync again - should return immediately due to early return
+    await NativePixelEncoder.initializeAsync({
+      logNativeEncodersMessages: false,
+    });
+
+    // Should still be initialized
+    expect(NativePixelEncoder.isInitialized()).to.be.eq(true);
+  });
+
+  describe('RLE Encoding', () => {
+    it('should correctly encode and decode basic RLE data', () => {
+      const width = 3;
+      const height = 3;
+      const originalData = Uint8Array.from([0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00]);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      // Encode the data
+      const encodedData = NativePixelEncoder.encodeRle(pixel, originalData);
+      expect(encodedData).to.be.instanceOf(Uint8Array);
+      expect(encodedData.length).to.be.greaterThan(0);
+
+      // Decode it back and verify
+      const decodedData = NativePixelDecoder.decodeRle(pixel, encodedData);
+      expect(decodedData).to.deep.equal(originalData);
+    });
+
+    it('should encode RLE with custom parameters', () => {
+      const width = 4;
+      const height = 4;
+      const originalData = Uint8Array.from([
+        0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff, 0x00,
+        0x00,
+      ]);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      const encodedData = NativePixelEncoder.encodeRle(pixel, originalData, {});
+      expect(encodedData).to.be.instanceOf(Uint8Array);
+
+      const decodedData = NativePixelDecoder.decodeRle(pixel, encodedData);
+      expect(decodedData).to.deep.equal(originalData);
+    });
+  });
+
+  describe('JPEG Encoding', () => {
+    it('should correctly encode and decode lossless JPEG data', () => {
+      const width = 4;
+      const height = 4;
+      const originalData = Uint8Array.from([
+        0x00, 0x80, 0xff, 0x40, 0x80, 0xff, 0x40, 0x00, 0xff, 0x40, 0x00, 0x80, 0x40, 0x00, 0x80,
+        0xff,
+      ]);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      // Test lossless encoding
+      const encodedData = NativePixelEncoder.encodeJpeg(pixel, originalData, {
+        lossless: true,
+      });
+      expect(encodedData).to.be.instanceOf(Uint8Array);
+      expect(encodedData.length).to.be.greaterThan(0);
+
+      const decodedData = NativePixelDecoder.decodeJpeg(pixel, encodedData);
+      expect(decodedData).to.deep.equal(originalData);
+    });
+
+    it('should encode JPEG with quality parameter', () => {
+      const width = 8;
+      const height = 8;
+      const originalData = new Uint8Array(width * height);
+
+      // Create a gradient pattern
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          originalData[y * width + x] = Math.floor(((x + y) * 255) / (width + height - 2));
+        }
+      }
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      // Test different quality levels
+      const highQualityEncoded = NativePixelEncoder.encodeJpeg(pixel, originalData, {
+        quality: 95,
+        lossless: false,
+      });
+      const lowQualityEncoded = NativePixelEncoder.encodeJpeg(pixel, originalData, {
+        quality: 10,
+        lossless: false,
+      });
+
+      expect(highQualityEncoded).to.be.instanceOf(Uint8Array);
+      expect(lowQualityEncoded).to.be.instanceOf(Uint8Array);
+      // Note: For small images, quality differences may not result in size differences
+      expect(lowQualityEncoded.length).to.be.lessThanOrEqual(highQualityEncoded.length);
+    });
+  });
+
+  describe('JPEG-LS Encoding', () => {
+    it('should correctly encode and decode lossless JPEG-LS data', () => {
+      const width = 4;
+      const height = 4;
+      const originalData = Uint8Array.from([
+        0x00, 0x40, 0x80, 0xff, 0x40, 0x80, 0xff, 0x00, 0x80, 0xff, 0x00, 0x40, 0xff, 0x00, 0x40,
+        0x80,
+      ]);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      const encodedData = NativePixelEncoder.encodeJpegLs(pixel, originalData, {
+        nearLossless: 0,
+      });
+      expect(encodedData).to.be.instanceOf(Uint8Array);
+      expect(encodedData.length).to.be.greaterThan(0);
+
+      const decodedData = NativePixelDecoder.decodeJpegLs(pixel, encodedData);
+      expect(decodedData).to.deep.equal(originalData);
+    });
+
+    it('should encode JPEG-LS with near-lossless parameter', () => {
+      const width = 8;
+      const height = 8;
+      const originalData = new Uint8Array(width * height);
+
+      // Create a smooth gradient
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          originalData[y * width + x] = Math.floor((x * y * 255) / ((width - 1) * (height - 1)));
+        }
+      }
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      // Test different near-lossless values
+      const losslessEncoded = NativePixelEncoder.encodeJpegLs(pixel, originalData, {
+        nearLossless: 0,
+      });
+      const nearLosslessEncoded = NativePixelEncoder.encodeJpegLs(pixel, originalData, {
+        nearLossless: 2,
+      });
+
+      expect(losslessEncoded).to.be.instanceOf(Uint8Array);
+      expect(nearLosslessEncoded).to.be.instanceOf(Uint8Array);
+      // Note: For small images, near-lossless may not always produce smaller files
+      expect(nearLosslessEncoded.length).to.be.lessThanOrEqual(losslessEncoded.length);
+    });
+  });
+
+  describe('JPEG2000 Encoding', () => {
+    it('should correctly encode and decode lossless JPEG2000 data', () => {
+      const width = 4;
+      const height = 4;
+      const originalData = Uint8Array.from([
+        0x00, 0x55, 0xaa, 0xff, 0x55, 0xaa, 0xff, 0x00, 0xaa, 0xff, 0x00, 0x55, 0xff, 0x00, 0x55,
+        0xaa,
+      ]);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      const encodedData = NativePixelEncoder.encodeJpeg2000(pixel, originalData, {
+        lossless: true,
+      });
+      expect(encodedData).to.be.instanceOf(Uint8Array);
+      expect(encodedData.length).to.be.greaterThan(0);
+
+      const decodedData = NativePixelDecoder.decodeJpeg2000(pixel, encodedData);
+      expect(decodedData).to.deep.equal(originalData);
+    });
+
+    it('should encode JPEG2000 with compression ratio', () => {
+      const width = 8;
+      const height = 8;
+      const originalData = new Uint8Array(width * height);
+
+      // Create a checkerboard pattern
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          originalData[y * width + x] = ((x + y) % 2) * 255;
+        }
+      }
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      // Test different compression ratios
+      const lowCompressionEncoded = NativePixelEncoder.encodeJpeg2000(pixel, originalData, {
+        compressionRatio: 2,
+        lossless: false,
+      });
+      const highCompressionEncoded = NativePixelEncoder.encodeJpeg2000(pixel, originalData, {
+        compressionRatio: 10,
+        lossless: false,
+      });
+
+      expect(lowCompressionEncoded).to.be.instanceOf(Uint8Array);
+      expect(highCompressionEncoded).to.be.instanceOf(Uint8Array);
+      // Note: For small images, compression ratio differences may not result in size differences
+      expect(highCompressionEncoded.length).to.be.lessThanOrEqual(lowCompressionEncoded.length);
+    });
+  });
+
+  describe('Multi-component Images', () => {
+    it('should encode RGB images correctly', () => {
+      const width = 4;
+      const height = 4;
+      const samplesPerPixel = 3;
+      const originalData = new Uint8Array(width * height * samplesPerPixel);
+
+      // Create RGB test pattern
+      for (let i = 0; i < width * height; i++) {
+        originalData[i * 3] = (i * 85) % 256; // Red
+        originalData[i * 3 + 1] = (i * 51) % 256; // Green
+        originalData[i * 3 + 2] = (i * 17) % 256; // Blue
+      }
+
+      const rgbImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        samplesPerPixel,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Rgb,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(rgbImage.getElements(), rgbImage.getTransferSyntaxUid());
+
+      // Test different encoding methods with RGB data
+      const rleEncoded = NativePixelEncoder.encodeRle(pixel, originalData);
+      expect(rleEncoded).to.be.instanceOf(Uint8Array);
+
+      const jpegLsEncoded = NativePixelEncoder.encodeJpegLs(pixel, originalData, {
+        nearLossless: 0,
+      });
+      expect(jpegLsEncoded).to.be.instanceOf(Uint8Array);
+
+      const jpeg2000Encoded = NativePixelEncoder.encodeJpeg2000(pixel, originalData, {
+        lossless: true,
+      });
+      expect(jpeg2000Encoded).to.be.instanceOf(Uint8Array);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle invalid pixel data gracefully', () => {
+      const width = 2;
+      const height = 2;
+      const invalidData = new Uint8Array(0); // Empty data
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        new ArrayBuffer(width * height), // Valid buffer size
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      expect(() => {
+        NativePixelEncoder.encodeRle(pixel, invalidData);
+      }).to.throw();
+    });
+
+    it('should handle null/undefined parameters', () => {
+      const width = 2;
+      const height = 2;
+      const testData = new Uint8Array(width * height);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        testData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      expect(() => {
+        NativePixelEncoder.encodeRle(null, testData);
+      }).to.throw();
+
+      expect(() => {
+        NativePixelEncoder.encodeRle(pixel, null);
+      }).to.throw();
+    });
+  });
+
+  describe('Performance and Edge Cases', () => {
+    it('should handle single pixel images', () => {
+      const width = 1;
+      const height = 1;
+      const originalData = Uint8Array.from([0x80]);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      const encodedData = NativePixelEncoder.encodeRle(pixel, originalData);
+      expect(encodedData).to.be.instanceOf(Uint8Array);
+
+      const decodedData = NativePixelDecoder.decodeRle(pixel, encodedData);
+      expect(decodedData).to.deep.equal(originalData);
+    });
+
+    it('should handle uniform pixel values', () => {
+      const width = 8;
+      const height = 8;
+      const uniformValue = 0x7f;
+      const originalData = new Uint8Array(width * height).fill(uniformValue);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      // RLE should be very efficient for uniform data
+      const rleEncoded = NativePixelEncoder.encodeRle(pixel, originalData);
+      // Note: RLE encoding includes headers and may not always be smaller for very small images
+      expect(rleEncoded.length).to.be.greaterThan(0);
+
+      const rleDecoded = NativePixelDecoder.decodeRle(pixel, rleEncoded);
+      expect(rleDecoded).to.deep.equal(originalData);
+
+      // JPEG-LS should also be efficient
+      const jpegLsEncoded = NativePixelEncoder.encodeJpegLs(pixel, originalData, {
+        nearLossless: 0,
+      });
+      expect(jpegLsEncoded.length).to.be.lessThan(originalData.length);
+
+      const jpegLsDecoded = NativePixelDecoder.decodeJpegLs(pixel, jpegLsEncoded);
+      expect(jpegLsDecoded).to.deep.equal(originalData);
+    });
+
+    it('should handle maximum pixel values', () => {
+      const width = 4;
+      const height = 4;
+      const originalData = new Uint8Array(width * height).fill(0xff);
+
+      const monoImage = createImageFromPixelData(
+        width,
+        height,
+        8,
+        8,
+        1,
+        PixelRepresentation.Unsigned,
+        PhotometricInterpretation.Monochrome2,
+        originalData.buffer,
+        TransferSyntax.ExplicitVRLittleEndian
+      );
+      const pixel = new Pixel(monoImage.getElements(), monoImage.getTransferSyntaxUid());
+
+      const encodedData = NativePixelEncoder.encodeJpeg2000(pixel, originalData, {
+        lossless: true,
+      });
+      expect(encodedData).to.be.instanceOf(Uint8Array);
+
+      const decodedData = NativePixelDecoder.decodeJpeg2000(pixel, encodedData);
+      expect(decodedData).to.deep.equal(originalData);
+    });
+  });
+});

--- a/test/Pixel.internals.test.js
+++ b/test/Pixel.internals.test.js
@@ -1,0 +1,751 @@
+const {
+  ColorPixelPipeline,
+  GrayscalePixelPipeline,
+  Pixel,
+  PixelConverter,
+  PixelPipeline,
+} = require('./../src/Pixel');
+const {
+  PhotometricInterpretation,
+  PixelRepresentation,
+  PlanarConfiguration,
+  TransferSyntax,
+} = require('./../src/Constants');
+const DicomImage = require('./../src/DicomImage');
+
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Pixel internals', () => {
+  describe('_getFrameFragments', () => {
+    it('should get frame fragments for single frame with single buffer', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Access private method for testing
+      const frameFragments = pixel._getFrameFragments(pixel.getPixelData(), 0);
+
+      expect(frameFragments).to.be.instanceof(Uint8Array);
+      expect(frameFragments.length).to.equal(4);
+      expect(Array.from(frameFragments)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should get frame fragments for single frame with multiple buffers', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2]).buffer, Uint8Array.from([3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Access private method for testing
+      const frameFragments = pixel._getFrameFragments(pixel.getPixelData(), 0);
+
+      expect(frameFragments).to.be.instanceof(Uint8Array);
+      expect(frameFragments.length).to.equal(4);
+      expect(Array.from(frameFragments)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should get frame fragments for multiple frames with one buffer per frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer, Uint8Array.from([5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Test first frame
+      const frameFragments0 = pixel._getFrameFragments(pixel.getPixelData(), 0);
+      expect(frameFragments0).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameFragments0)).to.deep.equal([1, 2, 3, 4]);
+
+      // Test second frame
+      const frameFragments1 = pixel._getFrameFragments(pixel.getPixelData(), 1);
+      expect(frameFragments1).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameFragments1)).to.deep.equal([5, 6, 7, 8]);
+    });
+
+    it('should throw error when getting frame fragments with no pixel data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      expect(() => {
+        pixel._getFrameFragments(pixel.getPixelData(), 0);
+      }).to.throw('No fragmented pixel data');
+    });
+
+    it('should throw error when getting frame fragments with frame out of range', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      expect(() => {
+        pixel._getFrameFragments(pixel.getPixelData(), 1);
+      }).to.throw('Requested frame is larger or equal to the pixel fragments number');
+    });
+  });
+
+  describe('_setFrameFragments', () => {
+    it('should set frame fragments for single frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const newFrameData = new Uint8Array([10, 20, 30, 40]);
+      const pixelBuffers = pixel.getPixelData();
+
+      // Set frame fragments
+      pixel._setFrameFragments(pixelBuffers, 0, newFrameData);
+
+      // Verify the data was set correctly
+      const retrievedData = new Uint8Array(pixelBuffers[0]);
+      expect(Array.from(retrievedData)).to.deep.equal([10, 20, 30, 40]);
+    });
+
+    it('should set frame fragments for multiple frames', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([1, 2, 3, 4]).buffer, new Uint16Array([5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const newFrameData = new Uint8Array(new Uint16Array([100, 200, 300, 400]).buffer);
+      const pixelBuffers = pixel.getPixelData();
+
+      // Set second frame fragments
+      pixel._setFrameFragments(pixelBuffers, 1, newFrameData);
+
+      // Verify the data was set correctly
+      const retrievedData = new Uint16Array(pixelBuffers[1]);
+      expect(Array.from(retrievedData)).to.deep.equal([100, 200, 300, 400]);
+
+      // Verify first frame was not affected
+      const firstFrameData = new Uint16Array(pixelBuffers[0]);
+      expect(Array.from(firstFrameData)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should throw error when setting frame fragments with invalid data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+      const pixelBuffers = pixel.getPixelData();
+
+      expect(() => {
+        pixel._setFrameFragments(pixelBuffers, 0, null);
+      }).to.throw('Frame data must be a Uint8Array');
+
+      expect(() => {
+        pixel._setFrameFragments(pixelBuffers, 0, 'invalid');
+      }).to.throw('Frame data must be a Uint8Array');
+    });
+  });
+
+  describe('_getFrameFragments & _setFrameFragments roundtrip ', () => {
+    it('should roundtrip frame fragments data correctly', () => {
+      // Use pre-generated random pixel data for realistic but deterministic testing
+      const initialFrame0Data = new Uint8Array([142, 73, 201, 89, 156, 34, 178, 251, 67]);
+      const initialFrame1Data = new Uint8Array([198, 45, 112, 233, 87, 159, 24, 203, 146]);
+
+      const image = new DicomImage(
+        {
+          Rows: 3,
+          Columns: 3,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [initialFrame0Data.buffer, initialFrame1Data.buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+      const pixelBuffers = pixel.getPixelData();
+
+      // Get original frame data
+      const originalFrame0 = pixel._getFrameFragments(pixelBuffers, 0);
+      const originalFrame1 = pixel._getFrameFragments(pixelBuffers, 1);
+
+      // Create new random frame data
+      const newFrame0Data = new Uint8Array([88, 215, 129, 56, 234, 91, 167, 42, 183]);
+      const newFrame1Data = new Uint8Array([77, 194, 38, 152, 219, 103, 241, 65, 128]);
+
+      // Set the new frame data
+      pixel._setFrameFragments(pixelBuffers, 0, newFrame0Data);
+      pixel._setFrameFragments(pixelBuffers, 1, newFrame1Data);
+
+      // Get the data back
+      const retrievedFrame0 = pixel._getFrameFragments(pixelBuffers, 0);
+      const retrievedFrame1 = pixel._getFrameFragments(pixelBuffers, 1);
+
+      // Verify roundtrip worked
+      expect(Array.from(retrievedFrame0)).to.deep.equal(Array.from(newFrame0Data));
+      expect(Array.from(retrievedFrame1)).to.deep.equal(Array.from(newFrame1Data));
+
+      // Verify original data is different
+      expect(Array.from(retrievedFrame0)).to.not.deep.equal(Array.from(originalFrame0));
+      expect(Array.from(retrievedFrame1)).to.not.deep.equal(Array.from(originalFrame1));
+    });
+
+    it('should handle roundtrip for single frame with multiple buffers', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2]).buffer, Uint8Array.from([3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+      const pixelBuffers = pixel.getPixelData();
+
+      // Get original concatenated frame data
+      const originalFrame = pixel._getFrameFragments(pixelBuffers, 0);
+      expect(Array.from(originalFrame)).to.deep.equal([1, 2, 3, 4]);
+
+      // Create new frame data
+      const newFrameData = new Uint8Array([10, 20, 30, 40]);
+
+      // Set the new frame data
+      pixel._setFrameFragments(pixelBuffers, 0, newFrameData);
+
+      // Get the data back
+      const retrievedFrame = pixel._getFrameFragments(pixelBuffers, 0);
+
+      // Verify roundtrip worked
+      expect(Array.from(retrievedFrame)).to.deep.equal(Array.from(newFrameData));
+      expect(Array.from(retrievedFrame)).to.not.deep.equal(Array.from(originalFrame));
+    });
+  });
+
+  describe('_getFrameBuffer', () => {
+    it('should get frame buffer for uncompressed single frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const frameBuffer = pixel._getFrameBuffer(0);
+
+      expect(frameBuffer).to.be.instanceof(Uint8Array);
+      expect(frameBuffer.length).to.equal(4);
+      expect(Array.from(frameBuffer)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should get frame buffer for uncompressed multiple frames', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Test first frame
+      const frameBuffer0 = pixel._getFrameBuffer(0);
+      expect(frameBuffer0).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameBuffer0)).to.deep.equal([1, 2, 3, 4]);
+
+      // Test second frame
+      const frameBuffer1 = pixel._getFrameBuffer(1);
+      expect(frameBuffer1).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameBuffer1)).to.deep.equal([5, 6, 7, 8]);
+    });
+
+    it('should get frame buffer for 16-bit uncompressed data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const frameBuffer = pixel._getFrameBuffer(0);
+
+      expect(frameBuffer).to.be.instanceof(Uint8Array);
+      expect(frameBuffer.length).to.equal(8); // 4 pixels * 2 bytes per pixel
+
+      // Convert back to 16-bit to verify
+      const uint16View = new Uint16Array(
+        frameBuffer.buffer,
+        frameBuffer.byteOffset,
+        frameBuffer.byteLength / 2
+      );
+      expect(Array.from(uint16View)).to.deep.equal([1000, 2000, 3000, 4000]);
+    });
+
+    it('should throw error when getting frame buffer with invalid parameters', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Test frame out of range
+      expect(() => {
+        pixel._getFrameBuffer(-1);
+      }).to.throw('Requested frame is out of range');
+
+      expect(() => {
+        pixel._getFrameBuffer(1);
+      }).to.throw('Requested frame is out of range');
+    });
+
+    it('should throw error when getting frame buffer with missing pixel data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      expect(() => {
+        pixel._getFrameBuffer(0);
+      }).to.throw('Could not extract pixel data');
+    });
+  });
+  describe('_setFrameBuffer', () => {
+    it('should set frame buffer for uncompressed single frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const newFrameData = new Uint8Array([10, 20, 30, 40]);
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Verify the data was set correctly by getting it back
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      expect(Array.from(retrievedFrameBuffer)).to.deep.equal([10, 20, 30, 40]);
+    });
+
+    it('should set frame buffer for uncompressed multiple frames', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Set second frame - using 8-bit values (0-255)
+      const newFrameData = new Uint8Array([100, 200, 150, 250]);
+      pixel._setFrameBuffer(1, newFrameData);
+
+      // Verify the second frame was set correctly
+      const retrievedFrame1 = pixel._getFrameBuffer(1);
+      expect(Array.from(retrievedFrame1)).to.deep.equal([100, 200, 150, 250]);
+
+      // Verify the first frame was not affected
+      const retrievedFrame0 = pixel._getFrameBuffer(0);
+      expect(Array.from(retrievedFrame0)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should set frame buffer for 16-bit uncompressed data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Create new frame data as bytes
+      const newFrameData = new Uint8Array(new Uint16Array([5000, 6000, 7000, 8000]).buffer);
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Verify the data was set correctly
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      const uint16View = new Uint16Array(
+        retrievedFrameBuffer.buffer,
+        retrievedFrameBuffer.byteOffset,
+        retrievedFrameBuffer.byteLength / 2
+      );
+      expect(Array.from(uint16View)).to.deep.equal([5000, 6000, 7000, 8000]);
+    });
+
+    it('should throw error when setting frame buffer with invalid parameters', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const validFrameData = new Uint8Array([10, 20, 30, 40]);
+
+      // Test frame out of range
+      expect(() => {
+        pixel._setFrameBuffer(-1, validFrameData);
+      }).to.throw('Requested frame is out of range');
+
+      expect(() => {
+        pixel._setFrameBuffer(1, validFrameData);
+      }).to.throw('Requested frame is out of range');
+
+      // Test invalid frame data
+      expect(() => {
+        pixel._setFrameBuffer(0, null);
+      }).to.throw('Frame data must be a Uint8Array');
+
+      expect(() => {
+        pixel._setFrameBuffer(0, 'invalid');
+      }).to.throw('Frame data must be a Uint8Array');
+    });
+
+    it('should handle big endian byte swapping correctly', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([0x1234, 0x5678, 0x9abc, 0xdef0]).buffer],
+        },
+        TransferSyntax.ExplicitVRBigEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Create new frame data
+      const newData = new Uint16Array([0x1111, 0x2222, 0x3333, 0x4444]);
+      const newFrameData = new Uint8Array(newData.buffer);
+
+      // Set the new frame data
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Get the data back and verify
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      const uint16View = new Uint16Array(
+        retrievedFrameBuffer.buffer,
+        retrievedFrameBuffer.byteOffset,
+        retrievedFrameBuffer.byteLength / 2
+      );
+      expect(Array.from(uint16View)).to.deep.equal([0x1111, 0x2222, 0x3333, 0x4444]);
+    });
+  });
+
+  describe('_getFrameBuffer & _setFrameBuffer roundtrip', () => {
+    it('should perform complete roundtrip for uncompressed data', () => {
+      // Test with various bit depths and configurations
+      const testCases = [
+        {
+          name: '8-bit grayscale',
+          config: {
+            Rows: 3,
+            Columns: 3,
+            BitsStored: 8,
+            BitsAllocated: 8,
+            SamplesPerPixel: 1,
+            PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+            PixelData: [new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer],
+          },
+          syntax: TransferSyntax.ImplicitVRLittleEndian,
+          newData: new Uint8Array([111, 122, 133, 144, 155, 166, 177, 188, 199]),
+        },
+        {
+          name: '16-bit grayscale',
+          config: {
+            Rows: 2,
+            Columns: 2,
+            BitsStored: 16,
+            BitsAllocated: 16,
+            SamplesPerPixel: 1,
+            PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+            PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
+          },
+          syntax: TransferSyntax.ExplicitVRLittleEndian,
+          newData: new Uint8Array(new Uint16Array([5555, 6666, 7777, 8888]).buffer),
+        },
+        {
+          name: '8-bit RGB',
+          config: {
+            Rows: 2,
+            Columns: 2,
+            BitsStored: 8,
+            BitsAllocated: 8,
+            SamplesPerPixel: 3,
+            PhotometricInterpretation: PhotometricInterpretation.Rgb,
+            PixelData: [new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255]).buffer],
+          },
+          syntax: TransferSyntax.ExplicitVRLittleEndian,
+          newData: new Uint8Array([128, 64, 32, 16, 8, 4, 2, 1, 200, 100, 50, 25]),
+        },
+      ];
+
+      testCases.forEach(({ name, config, syntax, newData }) => {
+        const image = new DicomImage(config, syntax);
+        const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+        // Get original frame buffer
+        const originalFrameBuffer = pixel._getFrameBuffer(0);
+
+        // Set new frame data
+        pixel._setFrameBuffer(0, newData);
+
+        // Get the data back
+        const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+
+        // Verify roundtrip worked
+        expect(Array.from(retrievedFrameBuffer)).to.deep.equal(
+          Array.from(newData),
+          `Failed for ${name}`
+        );
+
+        // Verify original data is different (unless by coincidence)
+        if (originalFrameBuffer.length === newData.length) {
+          const originalArray = Array.from(originalFrameBuffer);
+          const newArray = Array.from(newData);
+          expect(originalArray).to.not.deep.equal(
+            newArray,
+            `Original and new data should be different for ${name}`
+          );
+        }
+      });
+    });
+
+    it('should handle multi-frame roundtrip correctly', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 3,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [
+            new Uint8Array([
+              // Frame 0
+              1, 2, 3, 4,
+              // Frame 1
+              5, 6, 7, 8,
+              // Frame 2
+              9, 10, 11, 12,
+            ]).buffer,
+          ],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Get original frame buffers
+      const originalFrame0 = pixel._getFrameBuffer(0);
+      const originalFrame1 = pixel._getFrameBuffer(1);
+      const originalFrame2 = pixel._getFrameBuffer(2);
+
+      // Create new frame data - using 8-bit values (0-255)
+      const newFrame0Data = new Uint8Array([100, 101, 102, 103]);
+      const newFrame1Data = new Uint8Array([200, 201, 202, 203]);
+      const newFrame2Data = new Uint8Array([240, 241, 242, 243]);
+
+      // Set new frame data
+      pixel._setFrameBuffer(0, newFrame0Data);
+      pixel._setFrameBuffer(1, newFrame1Data);
+      pixel._setFrameBuffer(2, newFrame2Data);
+
+      // Get the data back
+      const retrievedFrame0 = pixel._getFrameBuffer(0);
+      const retrievedFrame1 = pixel._getFrameBuffer(1);
+      const retrievedFrame2 = pixel._getFrameBuffer(2);
+
+      // Verify roundtrip worked for all frames
+      expect(Array.from(retrievedFrame0)).to.deep.equal([100, 101, 102, 103]);
+      expect(Array.from(retrievedFrame1)).to.deep.equal([200, 201, 202, 203]);
+      expect(Array.from(retrievedFrame2)).to.deep.equal([240, 241, 242, 243]);
+
+      // Verify original data is different
+      expect(Array.from(retrievedFrame0)).to.not.deep.equal(Array.from(originalFrame0));
+      expect(Array.from(retrievedFrame1)).to.not.deep.equal(Array.from(originalFrame1));
+      expect(Array.from(retrievedFrame2)).to.not.deep.equal(Array.from(originalFrame2));
+    });
+
+    it('should handle frame buffer operations with pixel padding', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelPaddingValue: 0,
+          PixelData: [new Uint16Array([1000, 0, 3000, 0]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Get original frame buffer
+      const originalFrameBuffer = pixel._getFrameBuffer(0);
+      const originalUint16View = new Uint16Array(
+        originalFrameBuffer.buffer,
+        originalFrameBuffer.byteOffset,
+        originalFrameBuffer.byteLength / 2
+      );
+      expect(Array.from(originalUint16View)).to.deep.equal([1000, 0, 3000, 0]);
+
+      // Set new frame data with different padding
+      const newData = new Uint16Array([2000, 65535, 4000, 65535]);
+      const newFrameData = new Uint8Array(newData.buffer);
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Get the data back
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      const retrievedUint16View = new Uint16Array(
+        retrievedFrameBuffer.buffer,
+        retrievedFrameBuffer.byteOffset,
+        retrievedFrameBuffer.byteLength / 2
+      );
+      expect(Array.from(retrievedUint16View)).to.deep.equal([2000, 65535, 4000, 65535]);
+    });
+  });
+});

--- a/test/Pixel.test.js
+++ b/test/Pixel.test.js
@@ -185,6 +185,370 @@ describe('Pixel', () => {
     }).to.throw();
   });
 
+  it('should correctly get and set frame data as U8', () => {
+    const testData = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameDataU8
+    const frameData = pixel.getFrameDataU8(0);
+    expect(frameData).to.be.instanceof(Uint8Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameDataU8 and roundtrip
+    const newData = new Uint8Array([100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
+    pixel.setFrameDataU8(0, newData);
+    const retrievedData = pixel.getFrameDataU8(0);
+    expect(retrievedData).to.be.instanceof(Uint8Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data as U16', () => {
+    const testData = new Uint16Array([1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 16,
+        BitsAllocated: 16,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameDataU16
+    const frameData = pixel.getFrameDataU16(0);
+    expect(frameData).to.be.instanceof(Uint16Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameDataU16 and roundtrip
+    const newData = new Uint16Array([10000, 9000, 8000, 7000, 6000, 5000, 4000, 3000, 2000, 1000]);
+    pixel.setFrameDataU16(0, newData);
+    const retrievedData = pixel.getFrameDataU16(0);
+    expect(retrievedData).to.be.instanceof(Uint16Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data as S16', () => {
+    const testData = new Int16Array([-1000, -500, 0, 500, 1000, -2000, 2000, -3000, 3000, -4000]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 16,
+        BitsAllocated: 16,
+        PixelRepresentation: PixelRepresentation.Signed,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameDataS16
+    const frameData = pixel.getFrameDataS16(0);
+    expect(frameData).to.be.instanceof(Int16Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameDataS16 and roundtrip
+    const newData = new Int16Array([4000, -3000, 3000, -2000, 2000, -1000, 1000, -500, 500, 0]);
+    pixel.setFrameDataS16(0, newData);
+    const retrievedData = pixel.getFrameDataS16(0);
+    expect(retrievedData).to.be.instanceof(Int16Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data as S16 with bit shifting', () => {
+    const testData = new Uint16Array([
+      0x0800, 0x1000, 0x1800, 0x2000, 0x2800, 0x3000, 0x3800, 0x4000, 0x4800, 0x5000,
+    ]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 12,
+        BitsAllocated: 16,
+        HighBit: 11,
+        PixelRepresentation: PixelRepresentation.Signed,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameDataS16 with bit shifting
+    const frameData = pixel.getFrameDataS16(0);
+    expect(frameData).to.be.instanceof(Int16Array);
+    expect(frameData.length).to.equal(testData.length);
+
+    // Test setFrameDataS16 roundtrip with bit shifting
+    const newData = new Int16Array([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]);
+    pixel.setFrameDataS16(0, newData);
+    const retrievedData = pixel.getFrameDataS16(0);
+    expect(retrievedData).to.be.instanceof(Int16Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data as U32', () => {
+    const testData = new Uint32Array([
+      100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1000000,
+    ]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 32,
+        BitsAllocated: 32,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameDataU32
+    const frameData = pixel.getFrameDataU32(0);
+    expect(frameData).to.be.instanceof(Uint32Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameDataU32 and roundtrip
+    const newData = new Uint32Array([
+      1000000, 900000, 800000, 700000, 600000, 500000, 400000, 300000, 200000, 100000,
+    ]);
+    pixel.setFrameDataU32(0, newData);
+    const retrievedData = pixel.getFrameDataU32(0);
+    expect(retrievedData).to.be.instanceof(Uint32Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data as S32', () => {
+    const testData = new Int32Array([
+      -100000, -50000, 0, 50000, 100000, -200000, 200000, -300000, 300000, -400000,
+    ]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 32,
+        BitsAllocated: 32,
+        PixelRepresentation: PixelRepresentation.Signed,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameDataS32
+    const frameData = pixel.getFrameDataS32(0);
+    expect(frameData).to.be.instanceof(Int32Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameDataS32 and roundtrip
+    const newData = new Int32Array([
+      400000, -300000, 300000, -200000, 200000, -100000, 100000, -50000, 50000, 0,
+    ]);
+    pixel.setFrameDataS32(0, newData);
+    const retrievedData = pixel.getFrameDataS32(0);
+    expect(retrievedData).to.be.instanceof(Int32Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data as F32', () => {
+    const testData = new Float32Array([1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 32,
+        BitsAllocated: 32,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        FloatPixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameDataF32
+    const frameData = pixel.getFrameDataF32(0);
+    expect(frameData).to.be.instanceof(Float32Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.be.closeTo(testData[i], 0.001);
+    }
+
+    // Test setFrameDataF32 and roundtrip
+    const newData = new Float32Array([10.5, 9.5, 8.5, 7.5, 6.5, 5.5, 4.5, 3.5, 2.5, 1.5]);
+    pixel.setFrameDataF32(0, newData);
+    const retrievedData = pixel.getFrameDataF32(0);
+    expect(retrievedData).to.be.instanceof(Float32Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.be.closeTo(newData[i], 0.001);
+    }
+  });
+
+  it('should handle multi-frame data correctly', () => {
+    const frame1Data = new Uint8Array([10, 20, 30, 40]);
+    const frame2Data = new Uint8Array([50, 60, 70, 80]);
+    const combinedData = new Uint8Array([...frame1Data, ...frame2Data]);
+
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        NumberOfFrames: 2,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [combinedData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getting frame data for both frames
+    const frameData1 = pixel.getFrameDataU8(0);
+    const frameData2 = pixel.getFrameDataU8(1);
+
+    expect(frameData1.length).to.equal(4);
+    expect(frameData2.length).to.equal(4);
+
+    for (let i = 0; i < 4; i++) {
+      expect(frameData1[i]).to.equal(frame1Data[i]);
+      expect(frameData2[i]).to.equal(frame2Data[i]);
+    }
+
+    // Test setting frame data and roundtrip
+    const newFrame1Data = new Uint8Array([100, 110, 120, 130]);
+    const newFrame2Data = new Uint8Array([140, 150, 160, 170]);
+
+    pixel.setFrameDataU8(0, newFrame1Data);
+    pixel.setFrameDataU8(1, newFrame2Data);
+
+    const retrievedFrame1 = pixel.getFrameDataU8(0);
+    const retrievedFrame2 = pixel.getFrameDataU8(1);
+
+    for (let i = 0; i < 4; i++) {
+      expect(retrievedFrame1[i]).to.equal(newFrame1Data[i]);
+      expect(retrievedFrame2[i]).to.equal(newFrame2Data[i]);
+    }
+  });
+
+  it('should throw error for invalid frame index', () => {
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        NumberOfFrames: 1,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [new Uint8Array([1, 2, 3, 4]).buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test invalid frame index for get methods
+    expect(() => pixel.getFrameDataU8(1)).to.throw('Requested frame is out of range');
+    expect(() => pixel.getFrameDataU8(-1)).to.throw('Requested frame is out of range');
+
+    // Test invalid frame index for set methods
+    expect(() => pixel.setFrameDataU8(1, new Uint8Array([1, 2, 3, 4]))).to.throw(
+      'Requested frame is out of range'
+    );
+    expect(() => pixel.setFrameDataU8(-1, new Uint8Array([1, 2, 3, 4]))).to.throw(
+      'Requested frame is out of range'
+    );
+  });
+
+  it('should maintain data integrity across different typed array conversions', () => {
+    // Test conversion between U16 and S16
+    const testDataU16 = new Uint16Array([0x8000, 0x7fff, 0x0000, 0xffff]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        BitsStored: 16,
+        BitsAllocated: 16,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testDataU16.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Get as U16 and verify
+    const u16Data = pixel.getFrameDataU16(0);
+    for (let i = 0; i < testDataU16.length; i++) {
+      expect(u16Data[i]).to.equal(testDataU16[i]);
+    }
+
+    // Set back as U16 and verify roundtrip
+    pixel.setFrameDataU16(0, testDataU16);
+    const u16Retrieved = pixel.getFrameDataU16(0);
+    for (let i = 0; i < testDataU16.length; i++) {
+      expect(u16Retrieved[i]).to.equal(testDataU16[i]);
+    }
+  });
+
   it('should correctly construct a PixelPipeline from Pixel', () => {
     const image1 = new DicomImage(
       {
@@ -504,701 +868,5 @@ describe('Pixel', () => {
     for (let i = 0; i < 3 * width * height; i++) {
       expect(convertedRgbPixels[i]).to.be.eq(expectedRgbPixels[i]);
     }
-  });
-
-  describe('_getFrameFragments and _setFrameFragments', () => {
-    it('should get frame fragments for single frame with single buffer', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Access private method for testing
-      const frameFragments = pixel._getFrameFragments(pixel.getPixelData(), 0);
-
-      expect(frameFragments).to.be.instanceof(Uint8Array);
-      expect(frameFragments.length).to.equal(4);
-      expect(Array.from(frameFragments)).to.deep.equal([1, 2, 3, 4]);
-    });
-
-    it('should get frame fragments for single frame with multiple buffers', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2]).buffer, Uint8Array.from([3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Access private method for testing
-      const frameFragments = pixel._getFrameFragments(pixel.getPixelData(), 0);
-
-      expect(frameFragments).to.be.instanceof(Uint8Array);
-      expect(frameFragments.length).to.equal(4);
-      expect(Array.from(frameFragments)).to.deep.equal([1, 2, 3, 4]);
-    });
-
-    it('should get frame fragments for multiple frames with one buffer per frame', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          NumberOfFrames: 2,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer, Uint8Array.from([5, 6, 7, 8]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Test first frame
-      const frameFragments0 = pixel._getFrameFragments(pixel.getPixelData(), 0);
-      expect(frameFragments0).to.be.instanceof(Uint8Array);
-      expect(Array.from(frameFragments0)).to.deep.equal([1, 2, 3, 4]);
-
-      // Test second frame
-      const frameFragments1 = pixel._getFrameFragments(pixel.getPixelData(), 1);
-      expect(frameFragments1).to.be.instanceof(Uint8Array);
-      expect(Array.from(frameFragments1)).to.deep.equal([5, 6, 7, 8]);
-    });
-
-    it('should throw error when getting frame fragments with no pixel data', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      expect(() => {
-        pixel._getFrameFragments(pixel.getPixelData(), 0);
-      }).to.throw('No fragmented pixel data');
-    });
-
-    it('should throw error when getting frame fragments with frame out of range', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      expect(() => {
-        pixel._getFrameFragments(pixel.getPixelData(), 1);
-      }).to.throw('Requested frame is larger or equal to the pixel fragments number');
-    });
-
-    it('should set frame fragments for single frame', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      const newFrameData = new Uint8Array([10, 20, 30, 40]);
-      const pixelBuffers = pixel.getPixelData();
-
-      // Set frame fragments
-      pixel._setFrameFragments(pixelBuffers, 0, newFrameData);
-
-      // Verify the data was set correctly
-      const retrievedData = new Uint8Array(pixelBuffers[0]);
-      expect(Array.from(retrievedData)).to.deep.equal([10, 20, 30, 40]);
-    });
-
-    it('should set frame fragments for multiple frames', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 16,
-          BitsAllocated: 16,
-          SamplesPerPixel: 1,
-          NumberOfFrames: 2,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [new Uint16Array([1, 2, 3, 4]).buffer, new Uint16Array([5, 6, 7, 8]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      const newFrameData = new Uint8Array(new Uint16Array([100, 200, 300, 400]).buffer);
-      const pixelBuffers = pixel.getPixelData();
-
-      // Set second frame fragments
-      pixel._setFrameFragments(pixelBuffers, 1, newFrameData);
-
-      // Verify the data was set correctly
-      const retrievedData = new Uint16Array(pixelBuffers[1]);
-      expect(Array.from(retrievedData)).to.deep.equal([100, 200, 300, 400]);
-
-      // Verify first frame was not affected
-      const firstFrameData = new Uint16Array(pixelBuffers[0]);
-      expect(Array.from(firstFrameData)).to.deep.equal([1, 2, 3, 4]);
-    });
-
-    it('should throw error when setting frame fragments with invalid data', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-      const pixelBuffers = pixel.getPixelData();
-
-      expect(() => {
-        pixel._setFrameFragments(pixelBuffers, 0, null);
-      }).to.throw('Frame data must be a Uint8Array');
-
-      expect(() => {
-        pixel._setFrameFragments(pixelBuffers, 0, 'invalid');
-      }).to.throw('Frame data must be a Uint8Array');
-    });
-
-    it('should roundtrip frame fragments data correctly', () => {
-      // Use pre-generated random pixel data for realistic but deterministic testing
-      const initialFrame0Data = new Uint8Array([142, 73, 201, 89, 156, 34, 178, 251, 67]);
-      const initialFrame1Data = new Uint8Array([198, 45, 112, 233, 87, 159, 24, 203, 146]);
-
-      const image = new DicomImage(
-        {
-          Rows: 3,
-          Columns: 3,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          NumberOfFrames: 2,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [initialFrame0Data.buffer, initialFrame1Data.buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-      const pixelBuffers = pixel.getPixelData();
-
-      // Get original frame data
-      const originalFrame0 = pixel._getFrameFragments(pixelBuffers, 0);
-      const originalFrame1 = pixel._getFrameFragments(pixelBuffers, 1);
-
-      // Create new random frame data
-      const newFrame0Data = new Uint8Array([88, 215, 129, 56, 234, 91, 167, 42, 183]);
-      const newFrame1Data = new Uint8Array([77, 194, 38, 152, 219, 103, 241, 65, 128]);
-
-      // Set the new frame data
-      pixel._setFrameFragments(pixelBuffers, 0, newFrame0Data);
-      pixel._setFrameFragments(pixelBuffers, 1, newFrame1Data);
-
-      // Get the data back
-      const retrievedFrame0 = pixel._getFrameFragments(pixelBuffers, 0);
-      const retrievedFrame1 = pixel._getFrameFragments(pixelBuffers, 1);
-
-      // Verify roundtrip worked
-      expect(Array.from(retrievedFrame0)).to.deep.equal(Array.from(newFrame0Data));
-      expect(Array.from(retrievedFrame1)).to.deep.equal(Array.from(newFrame1Data));
-
-      // Verify original data is different
-      expect(Array.from(retrievedFrame0)).to.not.deep.equal(Array.from(originalFrame0));
-      expect(Array.from(retrievedFrame1)).to.not.deep.equal(Array.from(originalFrame1));
-    });
-
-    it('should handle roundtrip for single frame with multiple buffers', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2]).buffer, Uint8Array.from([3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-      const pixelBuffers = pixel.getPixelData();
-
-      // Get original concatenated frame data
-      const originalFrame = pixel._getFrameFragments(pixelBuffers, 0);
-      expect(Array.from(originalFrame)).to.deep.equal([1, 2, 3, 4]);
-
-      // Create new frame data
-      const newFrameData = new Uint8Array([10, 20, 30, 40]);
-
-      // Set the new frame data
-      pixel._setFrameFragments(pixelBuffers, 0, newFrameData);
-
-      // Get the data back
-      const retrievedFrame = pixel._getFrameFragments(pixelBuffers, 0);
-
-      // Verify roundtrip worked
-      expect(Array.from(retrievedFrame)).to.deep.equal(Array.from(newFrameData));
-      expect(Array.from(retrievedFrame)).to.not.deep.equal(Array.from(originalFrame));    });
-  });
-
-  describe('_getFrameBuffer and _setFrameBuffer', () => {
-    it('should get frame buffer for uncompressed single frame', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      const frameBuffer = pixel._getFrameBuffer(0);
-
-      expect(frameBuffer).to.be.instanceof(Uint8Array);
-      expect(frameBuffer.length).to.equal(4);
-      expect(Array.from(frameBuffer)).to.deep.equal([1, 2, 3, 4]);
-    });
-
-    it('should get frame buffer for uncompressed multiple frames', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          NumberOfFrames: 2,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Test first frame
-      const frameBuffer0 = pixel._getFrameBuffer(0);
-      expect(frameBuffer0).to.be.instanceof(Uint8Array);
-      expect(Array.from(frameBuffer0)).to.deep.equal([1, 2, 3, 4]);
-
-      // Test second frame
-      const frameBuffer1 = pixel._getFrameBuffer(1);
-      expect(frameBuffer1).to.be.instanceof(Uint8Array);
-      expect(Array.from(frameBuffer1)).to.deep.equal([5, 6, 7, 8]);
-    });
-
-    it('should get frame buffer for 16-bit uncompressed data', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 16,
-          BitsAllocated: 16,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      const frameBuffer = pixel._getFrameBuffer(0);
-
-      expect(frameBuffer).to.be.instanceof(Uint8Array);
-      expect(frameBuffer.length).to.equal(8); // 4 pixels * 2 bytes per pixel
-      
-      // Convert back to 16-bit to verify
-      const uint16View = new Uint16Array(frameBuffer.buffer, frameBuffer.byteOffset, frameBuffer.byteLength / 2);
-      expect(Array.from(uint16View)).to.deep.equal([1000, 2000, 3000, 4000]);
-    });
-
-    it('should throw error when getting frame buffer with invalid parameters', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Test frame out of range
-      expect(() => {
-        pixel._getFrameBuffer(-1);
-      }).to.throw('Requested frame is out of range');
-
-      expect(() => {
-        pixel._getFrameBuffer(1);
-      }).to.throw('Requested frame is out of range');
-    });
-
-    it('should throw error when getting frame buffer with missing pixel data', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      expect(() => {
-        pixel._getFrameBuffer(0);
-      }).to.throw('Could not extract pixel data');
-    });
-
-    it('should set frame buffer for uncompressed single frame', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      const newFrameData = new Uint8Array([10, 20, 30, 40]);
-      pixel._setFrameBuffer(0, newFrameData);
-
-      // Verify the data was set correctly by getting it back
-      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
-      expect(Array.from(retrievedFrameBuffer)).to.deep.equal([10, 20, 30, 40]);
-    });
-
-    it('should set frame buffer for uncompressed multiple frames', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          NumberOfFrames: 2,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Set second frame - using 8-bit values (0-255)
-      const newFrameData = new Uint8Array([100, 200, 150, 250]);
-      pixel._setFrameBuffer(1, newFrameData);
-
-      // Verify the second frame was set correctly
-      const retrievedFrame1 = pixel._getFrameBuffer(1);
-      expect(Array.from(retrievedFrame1)).to.deep.equal([100, 200, 150, 250]);
-
-      // Verify the first frame was not affected
-      const retrievedFrame0 = pixel._getFrameBuffer(0);
-      expect(Array.from(retrievedFrame0)).to.deep.equal([1, 2, 3, 4]);
-    });
-
-    it('should set frame buffer for 16-bit uncompressed data', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 16,
-          BitsAllocated: 16,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Create new frame data as bytes
-      const newFrameData = new Uint8Array(new Uint16Array([5000, 6000, 7000, 8000]).buffer);
-      pixel._setFrameBuffer(0, newFrameData);
-
-      // Verify the data was set correctly
-      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
-      const uint16View = new Uint16Array(retrievedFrameBuffer.buffer, retrievedFrameBuffer.byteOffset, retrievedFrameBuffer.byteLength / 2);
-      expect(Array.from(uint16View)).to.deep.equal([5000, 6000, 7000, 8000]);
-    });
-
-    it('should throw error when setting frame buffer with invalid parameters', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      const validFrameData = new Uint8Array([10, 20, 30, 40]);
-
-      // Test frame out of range
-      expect(() => {
-        pixel._setFrameBuffer(-1, validFrameData);
-      }).to.throw('Requested frame is out of range');
-
-      expect(() => {
-        pixel._setFrameBuffer(1, validFrameData);
-      }).to.throw('Requested frame is out of range');
-
-      // Test invalid frame data
-      expect(() => {
-        pixel._setFrameBuffer(0, null);
-      }).to.throw('Frame data must be a Uint8Array');
-
-      expect(() => {
-        pixel._setFrameBuffer(0, 'invalid');
-      }).to.throw('Frame data must be a Uint8Array');
-    });
-
-    it('should handle big endian byte swapping correctly', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 16,
-          BitsAllocated: 16,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [new Uint16Array([0x1234, 0x5678, 0x9ABC, 0xDEF0]).buffer],
-        },
-        TransferSyntax.ExplicitVRBigEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Create new frame data
-      const newData = new Uint16Array([0x1111, 0x2222, 0x3333, 0x4444]);
-      const newFrameData = new Uint8Array(newData.buffer);
-
-      // Set the new frame data
-      pixel._setFrameBuffer(0, newFrameData);
-
-      // Get the data back and verify
-      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
-      const uint16View = new Uint16Array(retrievedFrameBuffer.buffer, retrievedFrameBuffer.byteOffset, retrievedFrameBuffer.byteLength / 2);
-      expect(Array.from(uint16View)).to.deep.equal([0x1111, 0x2222, 0x3333, 0x4444]);
-    });
-
-    it('should perform complete roundtrip for uncompressed data', () => {
-      // Test with various bit depths and configurations
-      const testCases = [
-        {
-          name: '8-bit grayscale',
-          config: {
-            Rows: 3,
-            Columns: 3,
-            BitsStored: 8,
-            BitsAllocated: 8,
-            SamplesPerPixel: 1,
-            PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-            PixelData: [new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer],
-          },
-          syntax: TransferSyntax.ImplicitVRLittleEndian,
-          newData: new Uint8Array([111, 122, 133, 144, 155, 166, 177, 188, 199]),
-        },
-        {
-          name: '16-bit grayscale',
-          config: {
-            Rows: 2,
-            Columns: 2,
-            BitsStored: 16,
-            BitsAllocated: 16,
-            SamplesPerPixel: 1,
-            PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-            PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
-          },
-          syntax: TransferSyntax.ExplicitVRLittleEndian,
-          newData: new Uint8Array(new Uint16Array([5555, 6666, 7777, 8888]).buffer),
-        },
-        {
-          name: '8-bit RGB',
-          config: {
-            Rows: 2,
-            Columns: 2,
-            BitsStored: 8,
-            BitsAllocated: 8,
-            SamplesPerPixel: 3,
-            PhotometricInterpretation: PhotometricInterpretation.Rgb,
-            PixelData: [new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255]).buffer],
-          },
-          syntax: TransferSyntax.ExplicitVRLittleEndian,
-          newData: new Uint8Array([128, 64, 32, 16, 8, 4, 2, 1, 200, 100, 50, 25]),
-        },
-      ];
-
-      testCases.forEach(({ name, config, syntax, newData }) => {
-        const image = new DicomImage(config, syntax);
-        const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-        // Get original frame buffer
-        const originalFrameBuffer = pixel._getFrameBuffer(0);
-
-        // Set new frame data
-        pixel._setFrameBuffer(0, newData);
-
-        // Get the data back
-        const retrievedFrameBuffer = pixel._getFrameBuffer(0);
-
-        // Verify roundtrip worked
-        expect(Array.from(retrievedFrameBuffer)).to.deep.equal(Array.from(newData), `Failed for ${name}`);
-        
-        // Verify original data is different (unless by coincidence)
-        if (originalFrameBuffer.length === newData.length) {
-          const originalArray = Array.from(originalFrameBuffer);
-          const newArray = Array.from(newData);
-          expect(originalArray).to.not.deep.equal(newArray, `Original and new data should be different for ${name}`);
-        }
-      });
-    });
-
-    it('should handle multi-frame roundtrip correctly', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 8,
-          BitsAllocated: 8,
-          SamplesPerPixel: 1,
-          NumberOfFrames: 3,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelData: [new Uint8Array([
-            // Frame 0
-            1, 2, 3, 4,
-            // Frame 1
-            5, 6, 7, 8,
-            // Frame 2
-            9, 10, 11, 12
-          ]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Get original frame buffers
-      const originalFrame0 = pixel._getFrameBuffer(0);
-      const originalFrame1 = pixel._getFrameBuffer(1);
-      const originalFrame2 = pixel._getFrameBuffer(2);
-
-      // Create new frame data - using 8-bit values (0-255)
-      const newFrame0Data = new Uint8Array([100, 101, 102, 103]);
-      const newFrame1Data = new Uint8Array([200, 201, 202, 203]);
-      const newFrame2Data = new Uint8Array([240, 241, 242, 243]);
-
-      // Set new frame data
-      pixel._setFrameBuffer(0, newFrame0Data);
-      pixel._setFrameBuffer(1, newFrame1Data);
-      pixel._setFrameBuffer(2, newFrame2Data);
-
-      // Get the data back
-      const retrievedFrame0 = pixel._getFrameBuffer(0);
-      const retrievedFrame1 = pixel._getFrameBuffer(1);
-      const retrievedFrame2 = pixel._getFrameBuffer(2);
-
-      // Verify roundtrip worked for all frames
-      expect(Array.from(retrievedFrame0)).to.deep.equal([100, 101, 102, 103]);
-      expect(Array.from(retrievedFrame1)).to.deep.equal([200, 201, 202, 203]);
-      expect(Array.from(retrievedFrame2)).to.deep.equal([240, 241, 242, 243]);
-
-      // Verify original data is different
-      expect(Array.from(retrievedFrame0)).to.not.deep.equal(Array.from(originalFrame0));
-      expect(Array.from(retrievedFrame1)).to.not.deep.equal(Array.from(originalFrame1));
-      expect(Array.from(retrievedFrame2)).to.not.deep.equal(Array.from(originalFrame2));
-    });
-
-    it('should handle frame buffer operations with pixel padding', () => {
-      const image = new DicomImage(
-        {
-          Rows: 2,
-          Columns: 2,
-          BitsStored: 16,
-          BitsAllocated: 16,
-          SamplesPerPixel: 1,
-          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
-          PixelPaddingValue: 0,
-          PixelData: [new Uint16Array([1000, 0, 3000, 0]).buffer],
-        },
-        TransferSyntax.ImplicitVRLittleEndian
-      );
-      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
-
-      // Get original frame buffer
-      const originalFrameBuffer = pixel._getFrameBuffer(0);
-      const originalUint16View = new Uint16Array(originalFrameBuffer.buffer, originalFrameBuffer.byteOffset, originalFrameBuffer.byteLength / 2);
-      expect(Array.from(originalUint16View)).to.deep.equal([1000, 0, 3000, 0]);
-
-      // Set new frame data with different padding
-      const newData = new Uint16Array([2000, 65535, 4000, 65535]);
-      const newFrameData = new Uint8Array(newData.buffer);
-      pixel._setFrameBuffer(0, newFrameData);
-
-      // Get the data back
-      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
-      const retrievedUint16View = new Uint16Array(retrievedFrameBuffer.buffer, retrievedFrameBuffer.byteOffset, retrievedFrameBuffer.byteLength / 2);
-      expect(Array.from(retrievedUint16View)).to.deep.equal([2000, 65535, 4000, 65535]);
-    });
   });
 });

--- a/test/Pixel.test.js
+++ b/test/Pixel.test.js
@@ -869,4 +869,512 @@ describe('Pixel', () => {
       expect(convertedRgbPixels[i]).to.be.eq(expectedRgbPixels[i]);
     }
   });
+
+  // Tests for getFrameData and setFrameData methods
+  it('should correctly get and set frame data for 8-bit grayscale', () => {
+    const testData = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 5,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Uint8Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameData and roundtrip
+    const newData = new Uint8Array([100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Uint8Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data for 16-bit unsigned grayscale', () => {
+    const testData = new Uint16Array([1000, 2000, 3000, 4000, 5000, 6000]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 3,
+        BitsStored: 16,
+        BitsAllocated: 16,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Uint16Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameData and roundtrip
+    const newData = new Uint16Array([6000, 5000, 4000, 3000, 2000, 1000]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Uint16Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data for 16-bit signed grayscale', () => {
+    const testData = new Int16Array([-1000, -500, 0, 500, 1000, -2000]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 3,
+        BitsStored: 16,
+        BitsAllocated: 16,
+        PixelRepresentation: PixelRepresentation.Signed,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Int16Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameData and roundtrip
+    const newData = new Int16Array([2000, -1000, 1000, -500, 500, 0]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Int16Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data for 32-bit unsigned integer', () => {
+    const testData = new Uint32Array([100000, 200000, 300000, 400000]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        BitsStored: 32,
+        BitsAllocated: 32,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Uint32Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameData and roundtrip
+    const newData = new Uint32Array([400000, 300000, 200000, 100000]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Uint32Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data for 32-bit signed integer', () => {
+    const testData = new Int32Array([-100000, -50000, 50000, 100000]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        BitsStored: 32,
+        BitsAllocated: 32,
+        PixelRepresentation: PixelRepresentation.Signed,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Int32Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameData and roundtrip
+    const newData = new Int32Array([100000, -50000, 50000, -100000]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Int32Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data for 32-bit float', () => {
+    const testData = new Float32Array([1.5, 2.5, -3.5, 4.5]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        BitsStored: 32,
+        BitsAllocated: 32,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        FloatPixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Float32Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.be.closeTo(testData[i], 0.001);
+    }
+
+    // Test setFrameData and roundtrip
+    const newData = new Float32Array([4.5, -3.5, 2.5, 1.5]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Float32Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.be.closeTo(newData[i], 0.001);
+    }
+  });
+
+  it('should correctly get and set frame data for single bit (1-bit) images', () => {
+    // Create 1-bit test data: 2x4 image = 8 pixels packed into 1 byte
+    const packedData = new Uint8Array([0xAA]); // 10101010 in binary
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 4,
+        BitsStored: 1,
+        BitsAllocated: 1,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [packedData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData - should return expanded bits as Uint8Array
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Uint8Array);
+    expect(frameData.length).to.equal(8); // 8 pixels
+    expect(Array.from(frameData)).to.deep.equal([0, 1, 0, 1, 0, 1, 0, 1]);
+
+    // Test setFrameData and roundtrip
+    const newData = new Uint8Array([1, 0, 1, 0, 1, 0, 1, 0]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Uint8Array);
+    expect(retrievedData.length).to.equal(8);
+    expect(Array.from(retrievedData)).to.deep.equal([1, 0, 1, 0, 1, 0, 1, 0]);
+  });
+
+  it('should correctly get and set frame data for RGB interleaved color images', () => {
+    // Create RGB test data: 2x2 image = 4 pixels * 3 components = 12 bytes
+    const testData = new Uint8Array([
+      255, 0, 0,    // Red pixel
+      0, 255, 0,    // Green pixel
+      0, 0, 255,    // Blue pixel
+      128, 128, 128 // Gray pixel
+    ]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 3,
+        PlanarConfiguration: PlanarConfiguration.Interleaved,
+        PhotometricInterpretation: PhotometricInterpretation.Rgb,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Uint8Array);
+    expect(frameData.length).to.equal(testData.length);
+    for (let i = 0; i < testData.length; i++) {
+      expect(frameData[i]).to.equal(testData[i]);
+    }
+
+    // Test setFrameData and roundtrip
+    const newData = new Uint8Array([
+      128, 128, 128, // Gray pixel
+      0, 0, 255,     // Blue pixel
+      0, 255, 0,     // Green pixel
+      255, 0, 0      // Red pixel
+    ]);
+    pixel.setFrameData(0, newData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Uint8Array);
+    expect(retrievedData.length).to.equal(newData.length);
+    for (let i = 0; i < newData.length; i++) {
+      expect(retrievedData[i]).to.equal(newData[i]);
+    }
+  });
+
+  it('should correctly get and set frame data for RGB planar color images', () => {
+    // Create RGB planar test data: 2x2 image = 4 pixels * 3 components = 12 bytes
+    // Planar format: RRRR GGGG BBBB
+    const testData = new Uint8Array([
+      255, 0, 0, 128,    // Red channel
+      0, 255, 0, 128,    // Green channel
+      0, 0, 255, 128     // Blue channel
+    ]);
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 3,
+        PlanarConfiguration: PlanarConfiguration.Planar,
+        PhotometricInterpretation: PhotometricInterpretation.Rgb,
+        PixelData: [testData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getFrameData - should return interleaved format
+    const frameData = pixel.getFrameData(0);
+    expect(frameData).to.be.instanceof(Uint8Array);
+    expect(frameData.length).to.equal(testData.length);
+    // Should be converted to interleaved: RGB RGB RGB RGB
+    const expectedInterleaved = new Uint8Array([
+      255, 0, 0,    // Red pixel
+      0, 255, 0,    // Green pixel
+      0, 0, 255,    // Blue pixel
+      128, 128, 128 // Gray pixel
+    ]);
+    for (let i = 0; i < expectedInterleaved.length; i++) {
+      expect(frameData[i]).to.equal(expectedInterleaved[i]);
+    }
+
+    // Test setFrameData and roundtrip with interleaved data
+    const newInterleavedData = new Uint8Array([
+      128, 128, 128, // Gray pixel
+      0, 0, 255,     // Blue pixel
+      0, 255, 0,     // Green pixel
+      255, 0, 0      // Red pixel
+    ]);
+    pixel.setFrameData(0, newInterleavedData);
+    const retrievedData = pixel.getFrameData(0);
+    expect(retrievedData).to.be.instanceof(Uint8Array);
+    expect(retrievedData.length).to.equal(newInterleavedData.length);
+    for (let i = 0; i < newInterleavedData.length; i++) {
+      expect(retrievedData[i]).to.equal(newInterleavedData[i]);
+    }
+  });
+
+  it('should correctly handle multi-frame data with getFrameData and setFrameData', () => {
+    const frame1Data = new Uint8Array([10, 20, 30, 40]);
+    const frame2Data = new Uint8Array([50, 60, 70, 80]);
+    const combinedData = new Uint8Array([...frame1Data, ...frame2Data]);
+
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        NumberOfFrames: 2,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [combinedData.buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test getting frame data for both frames
+    const frameData1 = pixel.getFrameData(0);
+    const frameData2 = pixel.getFrameData(1);
+
+    expect(frameData1.length).to.equal(4);
+    expect(frameData2.length).to.equal(4);
+
+    for (let i = 0; i < 4; i++) {
+      expect(frameData1[i]).to.equal(frame1Data[i]);
+      expect(frameData2[i]).to.equal(frame2Data[i]);
+    }
+
+    // Test setting frame data and roundtrip
+    const newFrame1Data = new Uint8Array([100, 110, 120, 130]);
+    const newFrame2Data = new Uint8Array([140, 150, 160, 170]);
+
+    pixel.setFrameData(0, newFrame1Data);
+    pixel.setFrameData(1, newFrame2Data);
+
+    const retrievedFrame1 = pixel.getFrameData(0);
+    const retrievedFrame2 = pixel.getFrameData(1);
+
+    for (let i = 0; i < 4; i++) {
+      expect(retrievedFrame1[i]).to.equal(newFrame1Data[i]);
+      expect(retrievedFrame2[i]).to.equal(newFrame2Data[i]);
+    }
+  });
+
+  it('should maintain data type consistency in getFrameData/setFrameData roundtrip', () => {
+    // Test various data types to ensure roundtrip maintains correct types
+    const testCases = [
+      {
+        name: '8-bit unsigned',
+        data: new Uint8Array([10, 20, 30, 40]),
+        config: {
+          BitsStored: 8,
+          BitsAllocated: 8,
+          PixelRepresentation: PixelRepresentation.Unsigned,
+        },
+        expectedType: Uint8Array,
+      },
+      {
+        name: '16-bit unsigned',
+        data: new Uint16Array([1000, 2000, 3000, 4000]),
+        config: {
+          BitsStored: 16,
+          BitsAllocated: 16,
+          PixelRepresentation: PixelRepresentation.Unsigned,
+        },
+        expectedType: Uint16Array,
+      },
+      {
+        name: '16-bit signed',
+        data: new Int16Array([-1000, -500, 500, 1000]),
+        config: {
+          BitsStored: 16,
+          BitsAllocated: 16,
+          PixelRepresentation: PixelRepresentation.Signed,
+        },
+        expectedType: Int16Array,
+      },
+      {
+        name: '32-bit unsigned',
+        data: new Uint32Array([100000, 200000, 300000, 400000]),
+        config: {
+          BitsStored: 32,
+          BitsAllocated: 32,
+          PixelRepresentation: PixelRepresentation.Unsigned,
+        },
+        expectedType: Uint32Array,
+      },
+      {
+        name: '32-bit signed',
+        data: new Int32Array([-100000, -50000, 50000, 100000]),
+        config: {
+          BitsStored: 32,
+          BitsAllocated: 32,
+          PixelRepresentation: PixelRepresentation.Signed,
+        },
+        expectedType: Int32Array,
+      },
+    ];
+
+    testCases.forEach(({ name, data, config, expectedType }) => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [data.buffer],
+          ...config,
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Test getFrameData returns correct type
+      const frameData = pixel.getFrameData(0);
+      expect(frameData).to.be.instanceof(expectedType, `getFrameData failed for ${name}`);
+
+      // Test roundtrip maintains type and values
+      pixel.setFrameData(0, data);
+      const retrievedData = pixel.getFrameData(0);
+      expect(retrievedData).to.be.instanceof(expectedType, `roundtrip failed for ${name}`);
+      expect(retrievedData.length).to.equal(data.length, `length mismatch for ${name}`);
+
+      for (let i = 0; i < data.length; i++) {
+        expect(retrievedData[i]).to.equal(data[i], `value mismatch at index ${i} for ${name}`);
+      }
+    });
+  });
+
+  it('should throw error for invalid frame index in getFrameData and setFrameData', () => {
+    const image = new DicomImage(
+      {
+        Rows: 2,
+        Columns: 2,
+        NumberOfFrames: 1,
+        BitsStored: 8,
+        BitsAllocated: 8,
+        SamplesPerPixel: 1,
+        PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+        PixelData: [new Uint8Array([1, 2, 3, 4]).buffer],
+      },
+      TransferSyntax.ImplicitVRLittleEndian
+    );
+    const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+    // Test invalid frame index for getFrameData
+    expect(() => pixel.getFrameData(1)).to.throw('Requested frame is out of range');
+    expect(() => pixel.getFrameData(-1)).to.throw('Requested frame is out of range');
+
+    // Test invalid frame index for setFrameData
+    expect(() => pixel.setFrameData(1, new Uint8Array([1, 2, 3, 4]))).to.throw(
+      'Requested frame is out of range'
+    );
+    expect(() => pixel.setFrameData(-1, new Uint8Array([1, 2, 3, 4]))).to.throw(
+      'Requested frame is out of range'
+    );
+  });
 });

--- a/test/Pixel.test.js
+++ b/test/Pixel.test.js
@@ -505,4 +505,281 @@ describe('Pixel', () => {
       expect(convertedRgbPixels[i]).to.be.eq(expectedRgbPixels[i]);
     }
   });
+
+  describe('_getFrameFragments and _setFrameFragments', () => {
+    it('should get frame fragments for single frame with single buffer', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Access private method for testing
+      const frameFragments = pixel._getFrameFragments(pixel.getPixelData(), 0);
+
+      expect(frameFragments).to.be.instanceof(Uint8Array);
+      expect(frameFragments.length).to.equal(4);
+      expect(Array.from(frameFragments)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should get frame fragments for single frame with multiple buffers', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2]).buffer, Uint8Array.from([3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Access private method for testing
+      const frameFragments = pixel._getFrameFragments(pixel.getPixelData(), 0);
+
+      expect(frameFragments).to.be.instanceof(Uint8Array);
+      expect(frameFragments.length).to.equal(4);
+      expect(Array.from(frameFragments)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should get frame fragments for multiple frames with one buffer per frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer, Uint8Array.from([5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Test first frame
+      const frameFragments0 = pixel._getFrameFragments(pixel.getPixelData(), 0);
+      expect(frameFragments0).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameFragments0)).to.deep.equal([1, 2, 3, 4]);
+
+      // Test second frame
+      const frameFragments1 = pixel._getFrameFragments(pixel.getPixelData(), 1);
+      expect(frameFragments1).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameFragments1)).to.deep.equal([5, 6, 7, 8]);
+    });
+
+    it('should throw error when getting frame fragments with no pixel data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      expect(() => {
+        pixel._getFrameFragments(pixel.getPixelData(), 0);
+      }).to.throw('No fragmented pixel data');
+    });
+
+    it('should throw error when getting frame fragments with frame out of range', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      expect(() => {
+        pixel._getFrameFragments(pixel.getPixelData(), 1);
+      }).to.throw('Requested frame is larger or equal to the pixel fragments number');
+    });
+
+    it('should set frame fragments for single frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const newFrameData = new Uint8Array([10, 20, 30, 40]);
+      const pixelBuffers = pixel.getPixelData();
+
+      // Set frame fragments
+      pixel._setFrameFragments(pixelBuffers, 0, newFrameData);
+
+      // Verify the data was set correctly
+      const retrievedData = new Uint8Array(pixelBuffers[0]);
+      expect(Array.from(retrievedData)).to.deep.equal([10, 20, 30, 40]);
+    });
+
+    it('should set frame fragments for multiple frames', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([1, 2, 3, 4]).buffer, new Uint16Array([5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const newFrameData = new Uint8Array(new Uint16Array([100, 200, 300, 400]).buffer);
+      const pixelBuffers = pixel.getPixelData();
+
+      // Set second frame fragments
+      pixel._setFrameFragments(pixelBuffers, 1, newFrameData);
+
+      // Verify the data was set correctly
+      const retrievedData = new Uint16Array(pixelBuffers[1]);
+      expect(Array.from(retrievedData)).to.deep.equal([100, 200, 300, 400]);
+
+      // Verify first frame was not affected
+      const firstFrameData = new Uint16Array(pixelBuffers[0]);
+      expect(Array.from(firstFrameData)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should throw error when setting frame fragments with invalid data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+      const pixelBuffers = pixel.getPixelData();
+
+      expect(() => {
+        pixel._setFrameFragments(pixelBuffers, 0, null);
+      }).to.throw('Frame data must be a Uint8Array');
+
+      expect(() => {
+        pixel._setFrameFragments(pixelBuffers, 0, 'invalid');
+      }).to.throw('Frame data must be a Uint8Array');
+    });
+
+    it('should roundtrip frame fragments data correctly', () => {
+      // Use pre-generated random pixel data for realistic but deterministic testing
+      const initialFrame0Data = new Uint8Array([142, 73, 201, 89, 156, 34, 178, 251, 67]);
+      const initialFrame1Data = new Uint8Array([198, 45, 112, 233, 87, 159, 24, 203, 146]);
+
+      const image = new DicomImage(
+        {
+          Rows: 3,
+          Columns: 3,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [initialFrame0Data.buffer, initialFrame1Data.buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+      const pixelBuffers = pixel.getPixelData();
+
+      // Get original frame data
+      const originalFrame0 = pixel._getFrameFragments(pixelBuffers, 0);
+      const originalFrame1 = pixel._getFrameFragments(pixelBuffers, 1);
+
+      // Create new random frame data
+      const newFrame0Data = new Uint8Array([88, 215, 129, 56, 234, 91, 167, 42, 183]);
+      const newFrame1Data = new Uint8Array([77, 194, 38, 152, 219, 103, 241, 65, 128]);
+
+      // Set the new frame data
+      pixel._setFrameFragments(pixelBuffers, 0, newFrame0Data);
+      pixel._setFrameFragments(pixelBuffers, 1, newFrame1Data);
+
+      // Get the data back
+      const retrievedFrame0 = pixel._getFrameFragments(pixelBuffers, 0);
+      const retrievedFrame1 = pixel._getFrameFragments(pixelBuffers, 1);
+
+      // Verify roundtrip worked
+      expect(Array.from(retrievedFrame0)).to.deep.equal(Array.from(newFrame0Data));
+      expect(Array.from(retrievedFrame1)).to.deep.equal(Array.from(newFrame1Data));
+
+      // Verify original data is different
+      expect(Array.from(retrievedFrame0)).to.not.deep.equal(Array.from(originalFrame0));
+      expect(Array.from(retrievedFrame1)).to.not.deep.equal(Array.from(originalFrame1));
+    });
+
+    it('should handle roundtrip for single frame with multiple buffers', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2]).buffer, Uint8Array.from([3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+      const pixelBuffers = pixel.getPixelData();
+
+      // Get original concatenated frame data
+      const originalFrame = pixel._getFrameFragments(pixelBuffers, 0);
+      expect(Array.from(originalFrame)).to.deep.equal([1, 2, 3, 4]);
+
+      // Create new frame data
+      const newFrameData = new Uint8Array([10, 20, 30, 40]);
+
+      // Set the new frame data
+      pixel._setFrameFragments(pixelBuffers, 0, newFrameData);
+
+      // Get the data back
+      const retrievedFrame = pixel._getFrameFragments(pixelBuffers, 0);
+
+      // Verify roundtrip worked
+      expect(Array.from(retrievedFrame)).to.deep.equal(Array.from(newFrameData));
+      expect(Array.from(retrievedFrame)).to.not.deep.equal(Array.from(originalFrame));
+    });
+  });
 });

--- a/test/Pixel.test.js
+++ b/test/Pixel.test.js
@@ -1085,7 +1085,7 @@ describe('Pixel', () => {
 
   it('should correctly get and set frame data for single bit (1-bit) images', () => {
     // Create 1-bit test data: 2x4 image = 8 pixels packed into 1 byte
-    const packedData = new Uint8Array([0xAA]); // 10101010 in binary
+    const packedData = new Uint8Array([0xaa]); // 10101010 in binary
     const image = new DicomImage(
       {
         Rows: 2,
@@ -1118,10 +1118,18 @@ describe('Pixel', () => {
   it('should correctly get and set frame data for RGB interleaved color images', () => {
     // Create RGB test data: 2x2 image = 4 pixels * 3 components = 12 bytes
     const testData = new Uint8Array([
-      255, 0, 0,    // Red pixel
-      0, 255, 0,    // Green pixel
-      0, 0, 255,    // Blue pixel
-      128, 128, 128 // Gray pixel
+      255,
+      0,
+      0, // Red pixel
+      0,
+      255,
+      0, // Green pixel
+      0,
+      0,
+      255, // Blue pixel
+      128,
+      128,
+      128, // Gray pixel
     ]);
     const image = new DicomImage(
       {
@@ -1148,10 +1156,18 @@ describe('Pixel', () => {
 
     // Test setFrameData and roundtrip
     const newData = new Uint8Array([
-      128, 128, 128, // Gray pixel
-      0, 0, 255,     // Blue pixel
-      0, 255, 0,     // Green pixel
-      255, 0, 0      // Red pixel
+      128,
+      128,
+      128, // Gray pixel
+      0,
+      0,
+      255, // Blue pixel
+      0,
+      255,
+      0, // Green pixel
+      255,
+      0,
+      0, // Red pixel
     ]);
     pixel.setFrameData(0, newData);
     const retrievedData = pixel.getFrameData(0);
@@ -1166,9 +1182,18 @@ describe('Pixel', () => {
     // Create RGB planar test data: 2x2 image = 4 pixels * 3 components = 12 bytes
     // Planar format: RRRR GGGG BBBB
     const testData = new Uint8Array([
-      255, 0, 0, 128,    // Red channel
-      0, 255, 0, 128,    // Green channel
-      0, 0, 255, 128     // Blue channel
+      255,
+      0,
+      0,
+      128, // Red channel
+      0,
+      255,
+      0,
+      128, // Green channel
+      0,
+      0,
+      255,
+      128, // Blue channel
     ]);
     const image = new DicomImage(
       {
@@ -1191,10 +1216,18 @@ describe('Pixel', () => {
     expect(frameData.length).to.equal(testData.length);
     // Should be converted to interleaved: RGB RGB RGB RGB
     const expectedInterleaved = new Uint8Array([
-      255, 0, 0,    // Red pixel
-      0, 255, 0,    // Green pixel
-      0, 0, 255,    // Blue pixel
-      128, 128, 128 // Gray pixel
+      255,
+      0,
+      0, // Red pixel
+      0,
+      255,
+      0, // Green pixel
+      0,
+      0,
+      255, // Blue pixel
+      128,
+      128,
+      128, // Gray pixel
     ]);
     for (let i = 0; i < expectedInterleaved.length; i++) {
       expect(frameData[i]).to.equal(expectedInterleaved[i]);
@@ -1202,10 +1235,18 @@ describe('Pixel', () => {
 
     // Test setFrameData and roundtrip with interleaved data
     const newInterleavedData = new Uint8Array([
-      128, 128, 128, // Gray pixel
-      0, 0, 255,     // Blue pixel
-      0, 255, 0,     // Green pixel
-      255, 0, 0      // Red pixel
+      128,
+      128,
+      128, // Gray pixel
+      0,
+      0,
+      255, // Blue pixel
+      0,
+      255,
+      0, // Green pixel
+      255,
+      0,
+      0, // Red pixel
     ]);
     pixel.setFrameData(0, newInterleavedData);
     const retrievedData = pixel.getFrameData(0);

--- a/test/Pixel.test.js
+++ b/test/Pixel.test.js
@@ -779,7 +779,426 @@ describe('Pixel', () => {
 
       // Verify roundtrip worked
       expect(Array.from(retrievedFrame)).to.deep.equal(Array.from(newFrameData));
-      expect(Array.from(retrievedFrame)).to.not.deep.equal(Array.from(originalFrame));
+      expect(Array.from(retrievedFrame)).to.not.deep.equal(Array.from(originalFrame));    });
+  });
+
+  describe('_getFrameBuffer and _setFrameBuffer', () => {
+    it('should get frame buffer for uncompressed single frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const frameBuffer = pixel._getFrameBuffer(0);
+
+      expect(frameBuffer).to.be.instanceof(Uint8Array);
+      expect(frameBuffer.length).to.equal(4);
+      expect(Array.from(frameBuffer)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should get frame buffer for uncompressed multiple frames', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Test first frame
+      const frameBuffer0 = pixel._getFrameBuffer(0);
+      expect(frameBuffer0).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameBuffer0)).to.deep.equal([1, 2, 3, 4]);
+
+      // Test second frame
+      const frameBuffer1 = pixel._getFrameBuffer(1);
+      expect(frameBuffer1).to.be.instanceof(Uint8Array);
+      expect(Array.from(frameBuffer1)).to.deep.equal([5, 6, 7, 8]);
+    });
+
+    it('should get frame buffer for 16-bit uncompressed data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const frameBuffer = pixel._getFrameBuffer(0);
+
+      expect(frameBuffer).to.be.instanceof(Uint8Array);
+      expect(frameBuffer.length).to.equal(8); // 4 pixels * 2 bytes per pixel
+      
+      // Convert back to 16-bit to verify
+      const uint16View = new Uint16Array(frameBuffer.buffer, frameBuffer.byteOffset, frameBuffer.byteLength / 2);
+      expect(Array.from(uint16View)).to.deep.equal([1000, 2000, 3000, 4000]);
+    });
+
+    it('should throw error when getting frame buffer with invalid parameters', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Test frame out of range
+      expect(() => {
+        pixel._getFrameBuffer(-1);
+      }).to.throw('Requested frame is out of range');
+
+      expect(() => {
+        pixel._getFrameBuffer(1);
+      }).to.throw('Requested frame is out of range');
+    });
+
+    it('should throw error when getting frame buffer with missing pixel data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      expect(() => {
+        pixel._getFrameBuffer(0);
+      }).to.throw('Could not extract pixel data');
+    });
+
+    it('should set frame buffer for uncompressed single frame', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const newFrameData = new Uint8Array([10, 20, 30, 40]);
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Verify the data was set correctly by getting it back
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      expect(Array.from(retrievedFrameBuffer)).to.deep.equal([10, 20, 30, 40]);
+    });
+
+    it('should set frame buffer for uncompressed multiple frames', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 2,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Set second frame - using 8-bit values (0-255)
+      const newFrameData = new Uint8Array([100, 200, 150, 250]);
+      pixel._setFrameBuffer(1, newFrameData);
+
+      // Verify the second frame was set correctly
+      const retrievedFrame1 = pixel._getFrameBuffer(1);
+      expect(Array.from(retrievedFrame1)).to.deep.equal([100, 200, 150, 250]);
+
+      // Verify the first frame was not affected
+      const retrievedFrame0 = pixel._getFrameBuffer(0);
+      expect(Array.from(retrievedFrame0)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('should set frame buffer for 16-bit uncompressed data', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Create new frame data as bytes
+      const newFrameData = new Uint8Array(new Uint16Array([5000, 6000, 7000, 8000]).buffer);
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Verify the data was set correctly
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      const uint16View = new Uint16Array(retrievedFrameBuffer.buffer, retrievedFrameBuffer.byteOffset, retrievedFrameBuffer.byteLength / 2);
+      expect(Array.from(uint16View)).to.deep.equal([5000, 6000, 7000, 8000]);
+    });
+
+    it('should throw error when setting frame buffer with invalid parameters', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [Uint8Array.from([1, 2, 3, 4]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      const validFrameData = new Uint8Array([10, 20, 30, 40]);
+
+      // Test frame out of range
+      expect(() => {
+        pixel._setFrameBuffer(-1, validFrameData);
+      }).to.throw('Requested frame is out of range');
+
+      expect(() => {
+        pixel._setFrameBuffer(1, validFrameData);
+      }).to.throw('Requested frame is out of range');
+
+      // Test invalid frame data
+      expect(() => {
+        pixel._setFrameBuffer(0, null);
+      }).to.throw('Frame data must be a Uint8Array');
+
+      expect(() => {
+        pixel._setFrameBuffer(0, 'invalid');
+      }).to.throw('Frame data must be a Uint8Array');
+    });
+
+    it('should handle big endian byte swapping correctly', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint16Array([0x1234, 0x5678, 0x9ABC, 0xDEF0]).buffer],
+        },
+        TransferSyntax.ExplicitVRBigEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Create new frame data
+      const newData = new Uint16Array([0x1111, 0x2222, 0x3333, 0x4444]);
+      const newFrameData = new Uint8Array(newData.buffer);
+
+      // Set the new frame data
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Get the data back and verify
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      const uint16View = new Uint16Array(retrievedFrameBuffer.buffer, retrievedFrameBuffer.byteOffset, retrievedFrameBuffer.byteLength / 2);
+      expect(Array.from(uint16View)).to.deep.equal([0x1111, 0x2222, 0x3333, 0x4444]);
+    });
+
+    it('should perform complete roundtrip for uncompressed data', () => {
+      // Test with various bit depths and configurations
+      const testCases = [
+        {
+          name: '8-bit grayscale',
+          config: {
+            Rows: 3,
+            Columns: 3,
+            BitsStored: 8,
+            BitsAllocated: 8,
+            SamplesPerPixel: 1,
+            PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+            PixelData: [new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer],
+          },
+          syntax: TransferSyntax.ImplicitVRLittleEndian,
+          newData: new Uint8Array([111, 122, 133, 144, 155, 166, 177, 188, 199]),
+        },
+        {
+          name: '16-bit grayscale',
+          config: {
+            Rows: 2,
+            Columns: 2,
+            BitsStored: 16,
+            BitsAllocated: 16,
+            SamplesPerPixel: 1,
+            PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+            PixelData: [new Uint16Array([1000, 2000, 3000, 4000]).buffer],
+          },
+          syntax: TransferSyntax.ExplicitVRLittleEndian,
+          newData: new Uint8Array(new Uint16Array([5555, 6666, 7777, 8888]).buffer),
+        },
+        {
+          name: '8-bit RGB',
+          config: {
+            Rows: 2,
+            Columns: 2,
+            BitsStored: 8,
+            BitsAllocated: 8,
+            SamplesPerPixel: 3,
+            PhotometricInterpretation: PhotometricInterpretation.Rgb,
+            PixelData: [new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255]).buffer],
+          },
+          syntax: TransferSyntax.ExplicitVRLittleEndian,
+          newData: new Uint8Array([128, 64, 32, 16, 8, 4, 2, 1, 200, 100, 50, 25]),
+        },
+      ];
+
+      testCases.forEach(({ name, config, syntax, newData }) => {
+        const image = new DicomImage(config, syntax);
+        const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+        // Get original frame buffer
+        const originalFrameBuffer = pixel._getFrameBuffer(0);
+
+        // Set new frame data
+        pixel._setFrameBuffer(0, newData);
+
+        // Get the data back
+        const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+
+        // Verify roundtrip worked
+        expect(Array.from(retrievedFrameBuffer)).to.deep.equal(Array.from(newData), `Failed for ${name}`);
+        
+        // Verify original data is different (unless by coincidence)
+        if (originalFrameBuffer.length === newData.length) {
+          const originalArray = Array.from(originalFrameBuffer);
+          const newArray = Array.from(newData);
+          expect(originalArray).to.not.deep.equal(newArray, `Original and new data should be different for ${name}`);
+        }
+      });
+    });
+
+    it('should handle multi-frame roundtrip correctly', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 8,
+          BitsAllocated: 8,
+          SamplesPerPixel: 1,
+          NumberOfFrames: 3,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelData: [new Uint8Array([
+            // Frame 0
+            1, 2, 3, 4,
+            // Frame 1
+            5, 6, 7, 8,
+            // Frame 2
+            9, 10, 11, 12
+          ]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Get original frame buffers
+      const originalFrame0 = pixel._getFrameBuffer(0);
+      const originalFrame1 = pixel._getFrameBuffer(1);
+      const originalFrame2 = pixel._getFrameBuffer(2);
+
+      // Create new frame data - using 8-bit values (0-255)
+      const newFrame0Data = new Uint8Array([100, 101, 102, 103]);
+      const newFrame1Data = new Uint8Array([200, 201, 202, 203]);
+      const newFrame2Data = new Uint8Array([240, 241, 242, 243]);
+
+      // Set new frame data
+      pixel._setFrameBuffer(0, newFrame0Data);
+      pixel._setFrameBuffer(1, newFrame1Data);
+      pixel._setFrameBuffer(2, newFrame2Data);
+
+      // Get the data back
+      const retrievedFrame0 = pixel._getFrameBuffer(0);
+      const retrievedFrame1 = pixel._getFrameBuffer(1);
+      const retrievedFrame2 = pixel._getFrameBuffer(2);
+
+      // Verify roundtrip worked for all frames
+      expect(Array.from(retrievedFrame0)).to.deep.equal([100, 101, 102, 103]);
+      expect(Array.from(retrievedFrame1)).to.deep.equal([200, 201, 202, 203]);
+      expect(Array.from(retrievedFrame2)).to.deep.equal([240, 241, 242, 243]);
+
+      // Verify original data is different
+      expect(Array.from(retrievedFrame0)).to.not.deep.equal(Array.from(originalFrame0));
+      expect(Array.from(retrievedFrame1)).to.not.deep.equal(Array.from(originalFrame1));
+      expect(Array.from(retrievedFrame2)).to.not.deep.equal(Array.from(originalFrame2));
+    });
+
+    it('should handle frame buffer operations with pixel padding', () => {
+      const image = new DicomImage(
+        {
+          Rows: 2,
+          Columns: 2,
+          BitsStored: 16,
+          BitsAllocated: 16,
+          SamplesPerPixel: 1,
+          PhotometricInterpretation: PhotometricInterpretation.Monochrome2,
+          PixelPaddingValue: 0,
+          PixelData: [new Uint16Array([1000, 0, 3000, 0]).buffer],
+        },
+        TransferSyntax.ImplicitVRLittleEndian
+      );
+      const pixel = new Pixel(image.getElements(), image.getTransferSyntaxUid());
+
+      // Get original frame buffer
+      const originalFrameBuffer = pixel._getFrameBuffer(0);
+      const originalUint16View = new Uint16Array(originalFrameBuffer.buffer, originalFrameBuffer.byteOffset, originalFrameBuffer.byteLength / 2);
+      expect(Array.from(originalUint16View)).to.deep.equal([1000, 0, 3000, 0]);
+
+      // Set new frame data with different padding
+      const newData = new Uint16Array([2000, 65535, 4000, 65535]);
+      const newFrameData = new Uint8Array(newData.buffer);
+      pixel._setFrameBuffer(0, newFrameData);
+
+      // Get the data back
+      const retrievedFrameBuffer = pixel._getFrameBuffer(0);
+      const retrievedUint16View = new Uint16Array(retrievedFrameBuffer.buffer, retrievedFrameBuffer.byteOffset, retrievedFrameBuffer.byteLength / 2);
+      expect(Array.from(retrievedUint16View)).to.deep.equal([2000, 65535, 4000, 65535]);
     });
   });
 });


### PR DESCRIPTION
Added set frame data capabilities to Pixel and exported Pixel from the library.  This required creating a few new methods and modules to support bidirectional get/set of frame data.  Frame data for color images is not rendered to RGB as some of the conversion methods on one-way.

- Added new NativePixelEncoder
- Added implementation to support setting frame fragments and setting frame buffer
- Added set frame data methods for each array type pairing with the get frame data methods
- Added _shrinkBytes to SingleBitPixelPipeline as the reverse of _expandBits
- Added getFrameData and setFrameData that use the bit information in Pixel to call the appropriate getFrameDataX or setFrameDataX methods.  This could reduce the code in the PixelPipeline.create in the future, but I avoided touching that code.
- Added full tests for every addition.  I broke the white box tests for internal functions into its own file. 